### PR TITLE
[codex] Raise unlocked package coverage for entitlement provider

### DIFF
--- a/.github/workflows/release-unlocked-package.yml
+++ b/.github/workflows/release-unlocked-package.yml
@@ -200,6 +200,19 @@ jobs:
             exit 1
           fi
 
+          HAS_PASSED_CODE_COVERAGE_CHECK=$(echo "$RESULT" | jq -r '.result.HasPassedCodeCoverageCheck // "false"')
+          PACKAGE_CODE_COVERAGE=$(echo "$RESULT" | jq -r '.result.CodeCoverage // "unknown"')
+
+          echo "Package code coverage: $PACKAGE_CODE_COVERAGE"
+          echo "Has passed package code coverage gate: $HAS_PASSED_CODE_COVERAGE_CHECK"
+
+          if [ "$HAS_PASSED_CODE_COVERAGE_CHECK" != "true" ]; then
+            echo "Error: package version was created, but Salesforce reported that the package code coverage gate did not pass."
+            echo "CodeCoverage: $PACKAGE_CODE_COVERAGE"
+            echo "HasPassedCodeCoverageCheck: $HAS_PASSED_CODE_COVERAGE_CHECK"
+            exit 1
+          fi
+
           # Extract the subscriber package version ID (04t...)
           PACKAGE_VERSION_ID=$(echo "$RESULT" | jq -r '.result.SubscriberPackageVersionId')
 

--- a/force-app/main/default/classes/CatalogBuyerGroupAccessResolverTest.cls
+++ b/force-app/main/default/classes/CatalogBuyerGroupAccessResolverTest.cls
@@ -1,5 +1,70 @@
 @IsTest
 private class CatalogBuyerGroupAccessResolverTest {
+  private class NullFieldAccessBuilder
+    implements
+      ICatalogJsonBuilder,
+      ICatalogProductIdentityProvider,
+      ICatalogBuyerGroupAccessProvider {
+    public List<String> getRequiredProductFieldsForIdentity() {
+      return new List<String>{ 'ProductCode' };
+    }
+
+    public Map<Id, String> resolveEcProductIds(List<Product2> products) {
+      Map<Id, String> ecProductIds = new Map<Id, String>();
+      for (Product2 product : products) {
+        if (product != null && product.Id != null) {
+          ecProductIds.put(product.Id, product.ProductCode);
+        }
+      }
+      return ecProductIds;
+    }
+
+    public List<String> getRequiredProductFieldsForBuyerGroupAccess() {
+      return null;
+    }
+
+    public Map<Id, CatalogBuyerGroupAccessSnapshot> resolveBuyerGroupAccess(
+      CatalogJobConfig__mdt jobConfig,
+      List<Product2> products,
+      Map<Id, String> ecProductIdByProductId
+    ) {
+      Map<Id, CatalogBuyerGroupAccessSnapshot> snapshots =
+        new Map<Id, CatalogBuyerGroupAccessSnapshot>();
+
+      if (!products.isEmpty()) {
+        CatalogBuyerGroupAccessSnapshot snapshot =
+          new CatalogBuyerGroupAccessSnapshot();
+        snapshot.productId = products[0].Id;
+        snapshot.ecProductId = ecProductIdByProductId.get(products[0].Id);
+        snapshot.webStoreId = null;
+        snapshot.buyerGroupIds = null;
+        snapshot.buyerGroupNames = null;
+        snapshots.put(products[0].Id, snapshot);
+      }
+
+      return snapshots;
+    }
+
+    public String buildFullUpdateNdjson(
+      List<Product2> products,
+      Map<Id, Map<String, Decimal>> pricesByProduct,
+      List<String> extraFieldNames
+    ) {
+      return JSON.serialize(
+        new Map<String, Object>{ 'addOrUpdate' => new List<Object>() }
+      );
+    }
+
+    public String buildPartialMergeNdjson(
+      Map<String, Decimal> priceBySku,
+      Map<String, Boolean> inStockBySku
+    ) {
+      return JSON.serialize(
+        new Map<String, Object>{ 'addOrMerge' => new List<Object>() }
+      );
+    }
+  }
+
   private class CustomAccessBuilder
     implements
       ICatalogJsonBuilder,
@@ -175,5 +240,110 @@ private class CatalogBuyerGroupAccessResolverTest {
       );
 
     System.assertEquals(0, snapshots.size());
+  }
+
+  @IsTest
+  static void testGetProvider_returnsCustomAndFallbackProviders() {
+    System.assertEquals(
+      true,
+      CatalogBuyerGroupAccessResolver.getProvider(new CustomAccessBuilder()) instanceof
+      CustomAccessBuilder
+    );
+    System.assertEquals(
+      true,
+      CatalogBuyerGroupAccessResolver.getProvider(
+        new CatalogJobConfig__mdt(
+          BuilderType__c = 'CatalogJsonBuilderLegacyTestStub'
+        )
+      ) instanceof CatalogBuyerGroupEntitlementProvider
+    );
+  }
+
+  @IsTest
+  static void testGetRequiredProductFields_returnsEmptyWhenProviderReturnsNull() {
+    System.assertEquals(
+      0,
+      CatalogBuyerGroupAccessResolver.getRequiredProductFields(
+        new NullFieldAccessBuilder()
+      ).size()
+    );
+  }
+
+  @IsTest
+  static void testResolveBuyerGroupAccess_normalizesNullSetsAndSkipsMissingEcIds() {
+    List<Product2> products = new List<Product2>{
+      new Product2(
+        Id = Id.valueOf('01t000000000221AAA'),
+        ProductCode = 'EC-221'
+      ),
+      new Product2(
+        Id = Id.valueOf('01t000000000222AAA'),
+        ProductCode = 'EC-222'
+      )
+    };
+
+    Map<Id, CatalogBuyerGroupAccessSnapshot> snapshots =
+      CatalogBuyerGroupAccessResolver.resolveBuyerGroupAccess(
+        new CatalogJobConfig__mdt(WebStoreId__c = 'fallback-store'),
+        products,
+        new Map<Id, String>{ products[0].Id => 'EC-221' },
+        new NullFieldAccessBuilder()
+      );
+
+    System.assertEquals(
+      1,
+      snapshots.size(),
+      'Products without resolved ec_product_id values should be skipped during normalization'
+    );
+    System.assertEquals(
+      0,
+      snapshots.get(products[0].Id).buyerGroupIds.size(),
+      'Null Buyer Group ids should normalize to an empty set'
+    );
+    System.assertEquals(
+      0,
+      snapshots.get(products[0].Id).buyerGroupNames.size(),
+      'Null Buyer Group names should normalize to an empty set'
+    );
+    System.assertEquals(
+      'fallback-store',
+      snapshots.get(products[0].Id).webStoreId,
+      'Blank snapshot store values should fall back to the job config store'
+    );
+  }
+
+  @IsTest
+  static void testIndexSnapshotsByEcProductId_handlesNullAndBlankSnapshots() {
+    System.assertEquals(
+      0,
+      CatalogBuyerGroupAccessResolver.indexSnapshotsByEcProductId(null, 'store-1')
+        .size()
+    );
+
+    CatalogBuyerGroupAccessSnapshot blankSnapshot =
+      new CatalogBuyerGroupAccessSnapshot();
+    blankSnapshot.productId = Id.valueOf('01t000000000231AAA');
+    blankSnapshot.ecProductId = ' ';
+
+    CatalogBuyerGroupAccessSnapshot validSnapshot =
+      new CatalogBuyerGroupAccessSnapshot();
+    validSnapshot.productId = Id.valueOf('01t000000000232AAA');
+    validSnapshot.ecProductId = 'EC-232';
+    validSnapshot.buyerGroupIds.add('BG-232');
+
+    Map<String, CatalogBuyerGroupAccessSnapshot> indexedSnapshots =
+      CatalogBuyerGroupAccessResolver.indexSnapshotsByEcProductId(
+        new Map<Id, CatalogBuyerGroupAccessSnapshot>{
+          blankSnapshot.productId => blankSnapshot,
+          validSnapshot.productId => validSnapshot
+        },
+        'store-232'
+      );
+
+    System.assertEquals(1, indexedSnapshots.size());
+    System.assertEquals(
+      'store-232',
+      indexedSnapshots.get('EC-232').webStoreId
+    );
   }
 }

--- a/force-app/main/default/classes/CatalogBuyerGroupAvailabilityModeTest.cls
+++ b/force-app/main/default/classes/CatalogBuyerGroupAvailabilityModeTest.cls
@@ -92,4 +92,28 @@ private class CatalogBuyerGroupAvailabilityModeTest {
       CatalogBuyerGroupAvailabilityMode.resolveDraftMode(null)
     );
   }
+
+  @IsTest
+  static void testResolveAndLabels_coverNullConfigAndRemainingLabels() {
+    System.assertEquals(
+      CatalogBuyerGroupAvailabilityMode.DISABLED,
+      CatalogBuyerGroupAvailabilityMode.resolve(null)
+    );
+    System.assertEquals(
+      'Paired Availability Source',
+      CatalogBuyerGroupAvailabilityMode.getLabel(
+        CatalogBuyerGroupAvailabilityMode.PAIRED_SOURCE
+      )
+    );
+    System.assertEquals(
+      'Dual Write',
+      CatalogBuyerGroupAvailabilityMode.getLabel(
+        CatalogBuyerGroupAvailabilityMode.DUAL_WRITE
+      )
+    );
+    System.assertEquals(
+      'Disabled',
+      CatalogBuyerGroupAvailabilityMode.getLabel('banana')
+    );
+  }
 }

--- a/force-app/main/default/classes/CatalogBuyerGroupEntitlementProviderTest.cls
+++ b/force-app/main/default/classes/CatalogBuyerGroupEntitlementProviderTest.cls
@@ -1,0 +1,287 @@
+@IsTest
+private class CatalogBuyerGroupEntitlementProviderTest {
+  private static Boolean hasCommerceAvailabilitySchema() {
+    Map<String, Schema.SObjectType> globalDescribe = Schema.getGlobalDescribe();
+    return globalDescribe.containsKey('WebStore') &&
+      globalDescribe.containsKey('BuyerGroup') &&
+      globalDescribe.containsKey('WebStoreBuyerGroup') &&
+      globalDescribe.containsKey('CommerceEntitlementPolicy') &&
+      globalDescribe.containsKey('CommerceEntitlementBuyerGroup') &&
+      globalDescribe.containsKey('CommerceEntitlementProduct');
+  }
+
+  private static SObject createWebStore(String name) {
+    Schema.SObjectType webStoreType = Schema.getGlobalDescribe().get('WebStore');
+    System.assertNotEquals(
+      null,
+      webStoreType,
+      'WebStore should only be created in orgs where Commerce availability schema exists.'
+    );
+
+    SObject store = webStoreType.newSObject();
+    store.put('Name', name);
+    store.put('OptionsAutoFacetingEnabled', false);
+    store.put('OptionsCartAsyncProcessingEnabled', false);
+    store.put('OptionsCartCalculateEnabled', false);
+    store.put('OptionsCartToOrderAutoCustomFieldMapping', false);
+    store.put('OptionsCommerceEinsteinActivitiesTracked', false);
+    store.put('OptionsCommerceEinsteinDeployed', false);
+    store.put('OptionsDuplicateCartItemsEnabled', false);
+    store.put('OptionsGuestBrowsingEnabled', false);
+    store.put('OptionsGuestCartEnabled', false);
+    store.put('OptionsGuestCheckoutEnabled', false);
+    store.put('OptionsPreserveGuestCartEnabled', false);
+    store.put('OptionsSkipAdditionalEntitlementCheckForSearch', false);
+    store.put('OptionsSkuDetectionEnabled', false);
+    store.put('OptionsSplitShipmentEnabled', false);
+    insert store;
+    return store;
+  }
+
+  private static SObject createBuyerGroup(String name) {
+    SObject buyerGroup = Schema.getGlobalDescribe().get('BuyerGroup').newSObject();
+    buyerGroup.put('Name', name);
+    insert buyerGroup;
+    return buyerGroup;
+  }
+
+  private static SObject createPolicy(
+    String name,
+    Boolean canViewProduct,
+    Boolean canViewPrice
+  ) {
+    SObject policy = Schema.getGlobalDescribe()
+      .get('CommerceEntitlementPolicy')
+      .newSObject();
+    policy.put('Name', name);
+    policy.put('CanViewProduct', canViewProduct);
+    policy.put('CanViewPrice', canViewPrice);
+    insert policy;
+    return policy;
+  }
+
+  private static void linkWebStoreBuyerGroup(Id webStoreId, Id buyerGroupId) {
+    SObject link = Schema.getGlobalDescribe().get('WebStoreBuyerGroup').newSObject();
+    link.put('WebStoreId', webStoreId);
+    link.put('BuyerGroupId', buyerGroupId);
+    insert link;
+  }
+
+  private static void linkPolicyBuyerGroup(Id policyId, Id buyerGroupId) {
+    SObject link = Schema.getGlobalDescribe()
+      .get('CommerceEntitlementBuyerGroup')
+      .newSObject();
+    link.put('PolicyId', policyId);
+    link.put('BuyerGroupId', buyerGroupId);
+    insert link;
+  }
+
+  private static void linkPolicyProduct(Id policyId, Id productId) {
+    SObject link = Schema.getGlobalDescribe()
+      .get('CommerceEntitlementProduct')
+      .newSObject();
+    link.put('PolicyId', policyId);
+    link.put('ProductId', productId);
+    insert link;
+  }
+
+  private static Product2 createProduct(String code) {
+    Product2 product = new Product2(
+      Name = 'Entitlement Provider ' + code,
+      ProductCode = code,
+      Family = 'Hardware',
+      IsActive = true
+    );
+    insert product;
+    return product;
+  }
+
+  @IsTest
+  static void testGetRequiredProductFieldsForBuyerGroupAccess_returnsEmptyList() {
+    System.assertEquals(
+      0,
+      new CatalogBuyerGroupEntitlementProvider()
+        .getRequiredProductFieldsForBuyerGroupAccess()
+        .size()
+    );
+  }
+
+  @IsTest
+  static void testResolveBuyerGroupAccess_handlesIncompleteInputsGracefully() {
+    CatalogBuyerGroupEntitlementProvider provider =
+      new CatalogBuyerGroupEntitlementProvider();
+
+    System.assertEquals(
+      0,
+      provider.resolveBuyerGroupAccess(
+        null,
+        new List<Product2>(),
+        new Map<Id, String>()
+      ).size()
+    );
+    System.assertEquals(
+      0,
+      provider.resolveBuyerGroupAccess(
+        new CatalogJobConfig__mdt(WebStoreId__c = '0ZE000000000001AAA'),
+        new List<Product2>(),
+        new Map<Id, String>()
+      ).size()
+    );
+
+    Product2 product = new Product2(
+      Id = Id.valueOf('01t000000000501AAA'),
+      ProductCode = 'SKU-501'
+    );
+    System.assertEquals(
+      0,
+      provider.resolveBuyerGroupAccess(
+        new CatalogJobConfig__mdt(WebStoreId__c = '0ZE000000000001AAA'),
+        new List<Product2>{ product },
+        new Map<Id, String>()
+      ).size(),
+      'Products without resolved ec_product_id values should be ignored'
+    );
+  }
+
+  @IsTest
+  static void testResolveBuyerGroupAccess_returnsEmptyWhenStoreHasNoBuyerGroupsOrPolicies() {
+    if (!hasCommerceAvailabilitySchema()) {
+      return;
+    }
+
+    CatalogBuyerGroupEntitlementProvider provider =
+      new CatalogBuyerGroupEntitlementProvider();
+
+    SObject emptyStore = createWebStore('Provider Empty Store');
+    Product2 product = createProduct('SKU-EMPTY-001');
+    Map<Id, String> ecProductIdByProductId = new Map<Id, String>{
+      product.Id => 'EC-EMPTY-001'
+    };
+
+    System.assertEquals(
+      0,
+      provider.resolveBuyerGroupAccess(
+        new CatalogJobConfig__mdt(
+          WebStoreId__c = String.valueOf(emptyStore.get('Id'))
+        ),
+        new List<Product2>{ product },
+        ecProductIdByProductId
+      ).size(),
+      'Stores without Buyer Groups should not yield snapshots'
+    );
+
+    SObject noPolicyStore = createWebStore('Provider No Policy Store');
+    SObject buyerGroup = createBuyerGroup('Provider No Policy Buyers');
+    linkWebStoreBuyerGroup(
+      (Id) noPolicyStore.get('Id'),
+      (Id) buyerGroup.get('Id')
+    );
+
+    System.assertEquals(
+      0,
+      provider.resolveBuyerGroupAccess(
+        new CatalogJobConfig__mdt(
+          WebStoreId__c = String.valueOf(noPolicyStore.get('Id'))
+        ),
+        new List<Product2>{ product },
+        ecProductIdByProductId
+      ).size(),
+      'Buyer Groups without visible entitlement policies should not yield snapshots'
+    );
+  }
+
+  @IsTest
+  static void testResolveBuyerGroupAccess_returnsVisibleEntitlementsByProduct() {
+    if (!hasCommerceAvailabilitySchema()) {
+      return;
+    }
+
+    CatalogBuyerGroupEntitlementProvider provider =
+      new CatalogBuyerGroupEntitlementProvider();
+
+    Product2 alphaProduct = createProduct('SKU-ALPHA-001');
+    Product2 betaProduct = createProduct('SKU-BETA-001');
+    Product2 ignoredProduct = createProduct('SKU-IGNORED-001');
+
+    SObject store = createWebStore('Provider Coverage Store');
+    SObject alphaBuyerGroup = createBuyerGroup('Alpha Buyers');
+    SObject betaBuyerGroup = createBuyerGroup('Beta Buyers');
+    linkWebStoreBuyerGroup((Id) store.get('Id'), (Id) alphaBuyerGroup.get('Id'));
+    linkWebStoreBuyerGroup((Id) store.get('Id'), (Id) betaBuyerGroup.get('Id'));
+
+    SObject alphaVisiblePolicy = createPolicy('Alpha Visible Policy', true, false);
+    SObject alphaHiddenPolicy = createPolicy('Alpha Hidden Policy', false, false);
+    SObject betaVisiblePolicy = createPolicy('Beta Visible Policy', true, true);
+    linkPolicyBuyerGroup(
+      (Id) alphaVisiblePolicy.get('Id'),
+      (Id) alphaBuyerGroup.get('Id')
+    );
+    linkPolicyBuyerGroup(
+      (Id) alphaHiddenPolicy.get('Id'),
+      (Id) alphaBuyerGroup.get('Id')
+    );
+    linkPolicyBuyerGroup(
+      (Id) betaVisiblePolicy.get('Id'),
+      (Id) betaBuyerGroup.get('Id')
+    );
+
+    linkPolicyProduct((Id) alphaVisiblePolicy.get('Id'), alphaProduct.Id);
+    linkPolicyProduct((Id) alphaHiddenPolicy.get('Id'), betaProduct.Id);
+    linkPolicyProduct((Id) betaVisiblePolicy.get('Id'), betaProduct.Id);
+    linkPolicyProduct((Id) alphaVisiblePolicy.get('Id'), ignoredProduct.Id);
+
+    Map<Id, CatalogBuyerGroupAccessSnapshot> snapshotsByProductId =
+      provider.resolveBuyerGroupAccess(
+        new CatalogJobConfig__mdt(
+          WebStoreId__c = String.valueOf(store.get('Id'))
+        ),
+        new List<Product2>{ alphaProduct, betaProduct, ignoredProduct },
+        new Map<Id, String>{
+          alphaProduct.Id => 'EC-ALPHA-001',
+          betaProduct.Id => 'EC-BETA-001'
+        }
+      );
+
+    System.assertEquals(
+      2,
+      snapshotsByProductId.size(),
+      'Only products with resolved ec_product_id values and visible entitlements should be returned'
+    );
+
+    CatalogBuyerGroupAccessSnapshot alphaSnapshot = snapshotsByProductId.get(
+      alphaProduct.Id
+    );
+    System.assertEquals('EC-ALPHA-001', alphaSnapshot.ecProductId);
+    System.assertEquals(
+      JSON.serialize(new List<String>{ String.valueOf(alphaBuyerGroup.get('Id')) }),
+      JSON.serialize(alphaSnapshot.getSortedBuyerGroupIds())
+    );
+    System.assertEquals(
+      JSON.serialize(new List<String>{ 'Alpha Buyers' }),
+      JSON.serialize(alphaSnapshot.getSortedBuyerGroupNames())
+    );
+
+    CatalogBuyerGroupAccessSnapshot betaSnapshot = snapshotsByProductId.get(
+      betaProduct.Id
+    );
+    System.assertEquals('EC-BETA-001', betaSnapshot.ecProductId);
+    System.assertEquals(
+      JSON.serialize(new List<String>{ String.valueOf(betaBuyerGroup.get('Id')) }),
+      JSON.serialize(betaSnapshot.getSortedBuyerGroupIds()),
+      'Hidden policies should not contribute Buyer Group memberships'
+    );
+    System.assertEquals(
+      JSON.serialize(new List<String>{ 'Beta Buyers' }),
+      JSON.serialize(betaSnapshot.getSortedBuyerGroupNames())
+    );
+    System.assertEquals(
+      String.valueOf(store.get('Id')),
+      betaSnapshot.webStoreId
+    );
+    System.assertEquals(
+      false,
+      snapshotsByProductId.containsKey(ignoredProduct.Id),
+      'Products without resolved ec_product_id values should be skipped even when policies exist'
+    );
+  }
+}

--- a/force-app/main/default/classes/CatalogBuyerGroupEntitlementProviderTest.cls-meta.xml
+++ b/force-app/main/default/classes/CatalogBuyerGroupEntitlementProviderTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/CatalogJobRunner.cls
+++ b/force-app/main/default/classes/CatalogJobRunner.cls
@@ -244,6 +244,28 @@ public with sharing class CatalogJobRunner {
     Boolean runAvailability,
     String mode
   ) {
+    LaunchResult launch = createLaunchResult(config, mode);
+    JobLaunchHandle productLaunch = runProducts == true
+      ? launchProductJob(config.DeveloperName)
+      : null;
+    List<JobLaunchHandle> buyerGroupLaunches = runAvailability == true
+      ? launchBuyerGroupJobs(config)
+      : new List<JobLaunchHandle>();
+    appendLaunchHandles(
+      launch,
+      runProducts,
+      productLaunch,
+      runAvailability,
+      buyerGroupLaunches
+    );
+    return launch;
+  }
+
+  @TestVisible
+  private static LaunchResult createLaunchResult(
+    CatalogJobConfig__mdt config,
+    String mode
+  ) {
     LaunchResult launch = new LaunchResult();
     launch.runKey =
       config.DeveloperName +
@@ -260,16 +282,24 @@ public with sharing class CatalogJobRunner {
       CatalogBuyerGroupAvailabilityMode.resolve(config);
     launch.launchedAt = DateTime.now().formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
     launch.jobs = new List<JobLaunchHandle>();
-
-    if (runProducts == true) {
-      launch.jobs.add(launchProductJob(config.DeveloperName));
-    }
-
-    if (runAvailability == true) {
-      launch.jobs.addAll(launchBuyerGroupJobs(config));
-    }
-
     return launch;
+  }
+
+  @TestVisible
+  private static void appendLaunchHandles(
+    LaunchResult launch,
+    Boolean runProducts,
+    JobLaunchHandle productLaunch,
+    Boolean runAvailability,
+    List<JobLaunchHandle> buyerGroupLaunches
+  ) {
+    if (runProducts == true && productLaunch != null) {
+      launch.jobs.add(productLaunch);
+    }
+
+    if (runAvailability == true && buyerGroupLaunches != null) {
+      launch.jobs.addAll(buyerGroupLaunches);
+    }
   }
 
   private static JobLaunchHandle launchProductJob(String developerName) {
@@ -308,6 +338,7 @@ public with sharing class CatalogJobRunner {
     return launchHandles;
   }
 
+  @TestVisible
   private static JobLaunchHandle createLaunchHandle(
     Id jobId,
     String channel,
@@ -355,6 +386,7 @@ public with sharing class CatalogJobRunner {
     ];
   }
 
+  @TestVisible
   private static void validateBuyerGroupAccessEnabled(
     CatalogJobConfig__mdt config
   ) {
@@ -367,6 +399,7 @@ public with sharing class CatalogJobRunner {
     }
   }
 
+  @TestVisible
   private static String inferChannel(String apexClassName) {
     if (apexClassName == AVAILABILITY_BATCH_CLASS) {
       return 'availability';
@@ -377,6 +410,7 @@ public with sharing class CatalogJobRunner {
     return 'products';
   }
 
+  @TestVisible
   private static Boolean isTerminalStatus(String status) {
     return status == 'Completed' ||
       status == 'Failed' ||

--- a/force-app/main/default/classes/CatalogJobRunnerTest.cls
+++ b/force-app/main/default/classes/CatalogJobRunnerTest.cls
@@ -4,6 +4,15 @@ private class CatalogJobRunnerTest {
     public void execute(QueueableContext context) {}
   }
 
+  private static CatalogJobConfig__mdt findConfigByResolvedMode(String mode) {
+    for (CatalogJobConfig__mdt config : CatalogJobRunner.listConfigs()) {
+      if (CatalogBuyerGroupAvailabilityMode.resolve(config) == mode) {
+        return config;
+      }
+    }
+    return null;
+  }
+
   /**
    * Tests the listConfigs method which retrieves all CatalogJobConfig__mdt records.
    * Since Custom Metadata is read-only in tests, this test validates the method
@@ -139,6 +148,52 @@ private class CatalogJobRunnerTest {
   }
 
   @IsTest
+  static void testRunSingleAvailability_enqueuesEmbeddedAccessForEmbeddedConfig() {
+    CatalogJobConfig__mdt embeddedConfig = findConfigByResolvedMode(
+      CatalogBuyerGroupAvailabilityMode.EMBEDDED
+    );
+    if (embeddedConfig == null) {
+      System.assert(true, 'No embedded config available in this test context');
+      return;
+    }
+
+    Boolean exceptionThrown = false;
+    String exceptionMessage = '';
+    CatalogJobRunner.LaunchResult launchResult;
+
+    Test.getStandardPricebookId();
+
+    try {
+      launchResult = CatalogJobRunner.runSingleAvailability(
+        embeddedConfig.DeveloperName
+      );
+    } catch (Exception e) {
+      exceptionThrown = true;
+      exceptionMessage = e.getMessage();
+    }
+
+    if (!exceptionThrown) {
+      System.assertEquals(
+        CatalogBuyerGroupAvailabilityMode.EMBEDDED,
+        launchResult.buyerGroupAvailabilityMode
+      );
+      System.assertEquals(
+        1,
+        launchResult.jobs.size(),
+        'Embedded availability runs should launch one access refresh job'
+      );
+      System.assertEquals('access', launchResult.jobs[0].channel);
+    } else {
+      System.assert(
+        exceptionMessage.contains('List has no rows') ||
+          exceptionMessage.contains('No CatalogJobConfig__mdt record found'),
+        'Embedded runSingleAvailability should only fail for missing packaged prerequisites. ' +
+          exceptionMessage
+      );
+    }
+  }
+
+  @IsTest
   static void testRunSingleBoth_executesWithoutError() {
     Boolean exceptionThrown = false;
 
@@ -155,6 +210,69 @@ private class CatalogJobRunnerTest {
       exceptionThrown,
       'Missing config should still surface when running both exports'
     );
+  }
+
+  @IsTest
+  static void testRunSingleBoth_enqueuesProductAndBuyerGroupJobsForKnownModes() {
+    List<CatalogJobConfig__mdt> configsToExercise = new List<CatalogJobConfig__mdt>();
+
+    CatalogJobConfig__mdt pairedConfig = findConfigByResolvedMode(
+      CatalogBuyerGroupAvailabilityMode.PAIRED_SOURCE
+    );
+    if (pairedConfig != null) {
+      configsToExercise.add(pairedConfig);
+    }
+
+    CatalogJobConfig__mdt embeddedConfig = findConfigByResolvedMode(
+      CatalogBuyerGroupAvailabilityMode.EMBEDDED
+    );
+    if (embeddedConfig != null) {
+      configsToExercise.add(embeddedConfig);
+    }
+
+    if (configsToExercise.isEmpty()) {
+      System.assert(
+        true,
+        'No paired or embedded configs available in this test context'
+      );
+      return;
+    }
+
+    Test.getStandardPricebookId();
+
+    for (CatalogJobConfig__mdt config : configsToExercise) {
+      Boolean exceptionThrown = false;
+      String exceptionMessage = '';
+      CatalogJobRunner.LaunchResult launchResult;
+
+      try {
+        launchResult = CatalogJobRunner.runSingleBoth(config.DeveloperName);
+      } catch (Exception e) {
+        exceptionThrown = true;
+        exceptionMessage = e.getMessage();
+      }
+
+      if (!exceptionThrown) {
+        System.assertEquals(
+          'both',
+          launchResult.mode,
+          'Known configs should report the combined launch mode'
+        );
+        System.assertEquals(
+          2,
+          launchResult.jobs.size(),
+          'Combined launches should include a product sync and one Buyer Group access job'
+        );
+        System.assertEquals('products', launchResult.jobs[0].channel);
+      } else {
+        System.assert(
+          exceptionMessage.contains('List has no rows') ||
+            exceptionMessage.contains('No CatalogJobConfig__mdt record found'),
+          'Known combined launches should only fail for missing packaged prerequisites. ' +
+            exceptionMessage
+        );
+      }
+    }
   }
 
   @IsTest
@@ -353,5 +471,224 @@ private class CatalogJobRunnerTest {
       true,
       'All expected fields are accessible from query results'
     );
+  }
+
+  @IsTest
+  static void testCreateLaunchResult_populatesUiFieldsForEmbeddedMode() {
+    CatalogJobConfig__mdt config = new CatalogJobConfig__mdt(
+      DeveloperName = 'Embedded_Config',
+      Label = 'Embedded Config',
+      EnableBuyerGroupAvailability__c = true,
+      BuyerGroupAvailabilityMode__c = CatalogBuyerGroupAvailabilityMode.EMBEDDED
+    );
+
+    CatalogJobRunner.LaunchResult launch = CatalogJobRunner.createLaunchResult(
+      config,
+      'availability'
+    );
+
+    System.assertNotEquals(null, launch.runKey, 'Run key should be generated');
+    System.assert(
+      launch.runKey.startsWith('Embedded_Config-availability-'),
+      'Run key should include the config name and mode'
+    );
+    System.assertEquals('Embedded_Config', launch.developerName);
+    System.assertEquals('Embedded Config', launch.label);
+    System.assertEquals('availability', launch.mode);
+    System.assertEquals(true, launch.availabilityEnabled);
+    System.assertEquals(
+      CatalogBuyerGroupAvailabilityMode.EMBEDDED,
+      launch.buyerGroupAvailabilityMode
+    );
+    System.assertNotEquals(
+      null,
+      launch.launchedAt,
+      'Launch timestamp should be present'
+    );
+    System.assertNotEquals(null, launch.jobs, 'Job list should be initialized');
+    System.assertEquals(0, launch.jobs.size(), 'Job list should start empty');
+  }
+
+  @IsTest
+  static void testAppendLaunchHandles_addsOnlyRequestedHandles() {
+    CatalogJobRunner.LaunchResult launch = new CatalogJobRunner.LaunchResult();
+    launch.jobs = new List<CatalogJobRunner.JobLaunchHandle>();
+
+    CatalogJobRunner.JobLaunchHandle productHandle =
+      CatalogJobRunner.createLaunchHandle(
+        Test.getStandardPricebookId(),
+        'products',
+        'Product Sync'
+      );
+    List<CatalogJobRunner.JobLaunchHandle> accessHandles =
+      new List<CatalogJobRunner.JobLaunchHandle>{
+        CatalogJobRunner.createLaunchHandle(
+          UserInfo.getUserId(),
+          'access',
+          'Embedded Access Sync'
+        )
+      };
+
+    CatalogJobRunner.appendLaunchHandles(
+      launch,
+      true,
+      productHandle,
+      true,
+      accessHandles
+    );
+
+    System.assertEquals(2, launch.jobs.size());
+    System.assertEquals('products', launch.jobs[0].channel);
+    System.assertEquals('access', launch.jobs[1].channel);
+
+    CatalogJobRunner.LaunchResult skippedLaunch = new CatalogJobRunner.LaunchResult();
+    skippedLaunch.jobs = new List<CatalogJobRunner.JobLaunchHandle>();
+    CatalogJobRunner.appendLaunchHandles(
+      skippedLaunch,
+      false,
+      productHandle,
+      false,
+      accessHandles
+    );
+
+    System.assertEquals(
+      0,
+      skippedLaunch.jobs.size(),
+      'Handles should not be appended when both flags are false'
+    );
+  }
+
+  @IsTest
+  static void testCreateLaunchHandle_assignsValues() {
+    String expectedId = String.valueOf(Test.getStandardPricebookId());
+    CatalogJobRunner.JobLaunchHandle handle = CatalogJobRunner.createLaunchHandle(
+      Test.getStandardPricebookId(),
+      'availability',
+      'Availability Sync'
+    );
+
+    System.assertEquals(expectedId, handle.jobId);
+    System.assertEquals('availability', handle.channel);
+    System.assertEquals('Availability Sync', handle.label);
+  }
+
+  @IsTest
+  static void testValidateBuyerGroupAccessEnabled_handlesEnabledAndDisabledModes() {
+    CatalogJobConfig__mdt embeddedConfig = new CatalogJobConfig__mdt(
+      Label = 'Embedded Config',
+      EnableBuyerGroupAvailability__c = true,
+      BuyerGroupAvailabilityMode__c = CatalogBuyerGroupAvailabilityMode.EMBEDDED
+    );
+    CatalogJobConfig__mdt disabledConfig = new CatalogJobConfig__mdt(
+      Label = 'Disabled Config',
+      EnableBuyerGroupAvailability__c = false,
+      BuyerGroupAvailabilityMode__c = CatalogBuyerGroupAvailabilityMode.DISABLED
+    );
+
+    CatalogJobRunner.validateBuyerGroupAccessEnabled(embeddedConfig);
+
+    Boolean exceptionThrown = false;
+    try {
+      CatalogJobRunner.validateBuyerGroupAccessEnabled(disabledConfig);
+    } catch (CatalogJobConfigException e) {
+      exceptionThrown = true;
+      System.assert(
+        e.getMessage().contains('Buyer Group access is disabled for Disabled Config.'),
+        'The error should mention the disabled config label'
+      );
+    }
+
+    System.assertEquals(
+      true,
+      exceptionThrown,
+      'Disabled configs should fail validation'
+    );
+  }
+
+  @IsTest
+  static void testInferChannel_coversAvailabilityAccessAndDefaultMappings() {
+    System.assertEquals(
+      'availability',
+      CatalogJobRunner.inferChannel('BuyerGroupAvailabilityExportBatch')
+    );
+    System.assertEquals(
+      'access',
+      CatalogJobRunner.inferChannel('EmbeddedBuyerGroupAccessExportBatch')
+    );
+    System.assertEquals(
+      'products',
+      CatalogJobRunner.inferChannel('AnythingElse')
+    );
+    System.assertEquals('products', CatalogJobRunner.inferChannel(null));
+  }
+
+  @IsTest
+  static void testIsTerminalStatus_distinguishesCompletedFailedAbortedAndActiveStates() {
+    System.assertEquals(true, CatalogJobRunner.isTerminalStatus('Completed'));
+    System.assertEquals(true, CatalogJobRunner.isTerminalStatus('Failed'));
+    System.assertEquals(true, CatalogJobRunner.isTerminalStatus('Aborted'));
+    System.assertEquals(false, CatalogJobRunner.isTerminalStatus('Queued'));
+    System.assertEquals(false, CatalogJobRunner.isTerminalStatus(null));
+  }
+
+  @IsTest
+  static void testAuraDtos_supportPropertyAssignment() {
+    CatalogJobRunner.JobLaunchHandle handle = new CatalogJobRunner.JobLaunchHandle();
+    handle.jobId = '707000000000001AAA';
+    handle.channel = 'products';
+    handle.label = 'Product Sync';
+
+    CatalogJobRunner.LaunchResult launch = new CatalogJobRunner.LaunchResult();
+    launch.runKey = 'RunKey';
+    launch.developerName = 'Developer';
+    launch.label = 'Label';
+    launch.mode = 'products';
+    launch.availabilityEnabled = true;
+    launch.buyerGroupAvailabilityMode =
+      CatalogBuyerGroupAvailabilityMode.PAIRED_SOURCE;
+    launch.launchedAt = '2026-04-01T00:00:00Z';
+    launch.jobs = new List<CatalogJobRunner.JobLaunchHandle>{ handle };
+
+    CatalogJobRunner.RunSnapshot snapshot = new CatalogJobRunner.RunSnapshot();
+    snapshot.jobId = '707000000000002AAA';
+    snapshot.channel = 'access';
+    snapshot.apexClassName = 'EmbeddedBuyerGroupAccessExportBatch';
+    snapshot.status = 'Completed';
+    snapshot.jobItemsProcessed = 10;
+    snapshot.totalJobItems = 10;
+    snapshot.numberOfErrors = 0;
+    snapshot.extendedStatus = 'Done';
+    snapshot.isTerminal = true;
+    snapshot.createdDate = '2026-04-01T00:00:00Z';
+    snapshot.completedDate = '2026-04-01T00:01:00Z';
+
+    System.assertEquals('707000000000001AAA', handle.jobId);
+    System.assertEquals('products', handle.channel);
+    System.assertEquals('Product Sync', handle.label);
+    System.assertEquals('RunKey', launch.runKey);
+    System.assertEquals('Developer', launch.developerName);
+    System.assertEquals('Label', launch.label);
+    System.assertEquals('products', launch.mode);
+    System.assertEquals(true, launch.availabilityEnabled);
+    System.assertEquals(
+      CatalogBuyerGroupAvailabilityMode.PAIRED_SOURCE,
+      launch.buyerGroupAvailabilityMode
+    );
+    System.assertEquals('2026-04-01T00:00:00Z', launch.launchedAt);
+    System.assertEquals(1, launch.jobs.size());
+    System.assertEquals('707000000000002AAA', snapshot.jobId);
+    System.assertEquals('access', snapshot.channel);
+    System.assertEquals(
+      'EmbeddedBuyerGroupAccessExportBatch',
+      snapshot.apexClassName
+    );
+    System.assertEquals('Completed', snapshot.status);
+    System.assertEquals(10, snapshot.jobItemsProcessed);
+    System.assertEquals(10, snapshot.totalJobItems);
+    System.assertEquals(0, snapshot.numberOfErrors);
+    System.assertEquals('Done', snapshot.extendedStatus);
+    System.assertEquals(true, snapshot.isTerminal);
+    System.assertEquals('2026-04-01T00:00:00Z', snapshot.createdDate);
+    System.assertEquals('2026-04-01T00:01:00Z', snapshot.completedDate);
   }
 }

--- a/force-app/main/default/classes/CatalogProductIdentityResolverTest.cls
+++ b/force-app/main/default/classes/CatalogProductIdentityResolverTest.cls
@@ -30,6 +30,72 @@ private class CatalogProductIdentityResolverTest {
     }
   }
 
+  private class NullFieldIdentityProvider
+    implements ICatalogJsonBuilder, ICatalogProductIdentityProvider {
+    public List<String> getRequiredProductFieldsForIdentity() {
+      return new List<String>{ null, ' ', 'ProductCode', ' ProductCode ' };
+    }
+
+    public Map<Id, String> resolveEcProductIds(List<Product2> products) {
+      Map<Id, String> resolvedIds = new Map<Id, String>();
+      for (Product2 product : products) {
+        if (product != null && product.Id != null) {
+          resolvedIds.put(product.Id, 'EC-' + product.Id);
+        }
+      }
+      return resolvedIds;
+    }
+
+    public String buildFullUpdateNdjson(
+      List<Product2> products,
+      Map<Id, Map<String, Decimal>> pricesByProduct,
+      List<String> extraFieldNames
+    ) {
+      return JSON.serialize(
+        new Map<String, Object>{ 'addOrUpdate' => new List<Object>() }
+      );
+    }
+
+    public String buildPartialMergeNdjson(
+      Map<String, Decimal> priceBySku,
+      Map<String, Boolean> inStockBySku
+    ) {
+      return JSON.serialize(
+        new Map<String, Object>{ 'addOrMerge' => new List<Object>() }
+      );
+    }
+  }
+
+  private class NullListIdentityProvider
+    implements ICatalogJsonBuilder, ICatalogProductIdentityProvider {
+    public List<String> getRequiredProductFieldsForIdentity() {
+      return null;
+    }
+
+    public Map<Id, String> resolveEcProductIds(List<Product2> products) {
+      return new Map<Id, String>();
+    }
+
+    public String buildFullUpdateNdjson(
+      List<Product2> products,
+      Map<Id, Map<String, Decimal>> pricesByProduct,
+      List<String> extraFieldNames
+    ) {
+      return JSON.serialize(
+        new Map<String, Object>{ 'addOrUpdate' => new List<Object>() }
+      );
+    }
+
+    public String buildPartialMergeNdjson(
+      Map<String, Decimal> priceBySku,
+      Map<String, Boolean> inStockBySku
+    ) {
+      return JSON.serialize(
+        new Map<String, Object>{ 'addOrMerge' => new List<Object>() }
+      );
+    }
+  }
+
   @IsTest
   static void testGetRequiredProductFields_fallbackUsesProductCode() {
     List<String> requiredFields =
@@ -131,5 +197,95 @@ private class CatalogProductIdentityResolverTest {
     }
 
     System.assertEquals(true, failed);
+  }
+
+  @IsTest
+  static void testSupportsBuilderDrivenIdentity_coversBuilderStringAndConfigPaths() {
+    System.assertEquals(
+      true,
+      CatalogProductIdentityResolver.supportsBuilderDrivenIdentity(
+        new CatalogJobConfig__mdt(
+          BuilderType__c = 'CatalogJsonBuilderCreatedByIdStub'
+        )
+      )
+    );
+    System.assertEquals(
+      true,
+      CatalogProductIdentityResolver.supportsBuilderDrivenIdentity(
+        'CatalogJsonBuilderSkuIdentityStub'
+      )
+    );
+    System.assertEquals(
+      false,
+      CatalogProductIdentityResolver.supportsBuilderDrivenIdentity(
+        (ICatalogJsonBuilder) new CatalogJsonBuilderLegacyTestStub()
+      )
+    );
+  }
+
+  @IsTest
+  static void testGetRequiredProductFields_handlesNullAndBlankProviderFields() {
+    System.assertEquals(
+      new List<String>{ 'Id', 'ProductCode' },
+      CatalogProductIdentityResolver.getRequiredProductFields(
+        new NullFieldIdentityProvider()
+      ),
+      'Provider-required fields should be trimmed, deduplicated, and ignore blanks'
+    );
+    System.assertEquals(
+      new List<String>{ 'Id' },
+      CatalogProductIdentityResolver.getRequiredProductFields(
+        new NullListIdentityProvider()
+      ),
+      'A null provider field list should fall back to only Id'
+    );
+  }
+
+  @IsTest
+  static void testResolveEcProductIds_handlesNullEmptyAndMissingIds() {
+    System.assertEquals(
+      0,
+      CatalogProductIdentityResolver.resolveEcProductIds(
+        new CatalogJsonBuilderLegacyTestStub(),
+        new List<Product2>()
+      ).size(),
+      'Empty product scopes should resolve to an empty identity map'
+    );
+    System.assertEquals(
+      0,
+      CatalogProductIdentityResolver.resolveFallbackEcProductIds(null).size(),
+      'Null fallback inputs should resolve to an empty identity map'
+    );
+
+    Boolean fallbackFailed = false;
+    try {
+      CatalogProductIdentityResolver.resolveFallbackEcProductIds(
+        new List<Product2>{ new Product2(ProductCode = 'NO-ID') }
+      );
+    } catch (CatalogJobException ex) {
+      fallbackFailed = true;
+      System.assert(ex.getMessage().contains('requires every product to include an Id'));
+    }
+    System.assertEquals(
+      true,
+      fallbackFailed,
+      'Fallback identity resolution should reject products without Id values'
+    );
+
+    Boolean providerFailed = false;
+    try {
+      CatalogProductIdentityResolver.resolveEcProductIds(
+        new NullFieldIdentityProvider(),
+        new List<Product2>{ new Product2(ProductCode = 'NO-ID') }
+      );
+    } catch (CatalogJobException ex) {
+      providerFailed = true;
+      System.assert(ex.getMessage().contains('requires every product to include an Id'));
+    }
+    System.assertEquals(
+      true,
+      providerFailed,
+      'Provider-driven identity resolution should reject products without Id values'
+    );
   }
 }

--- a/force-app/main/default/classes/CoveoCommerceSetupControllerTest.cls
+++ b/force-app/main/default/classes/CoveoCommerceSetupControllerTest.cls
@@ -534,6 +534,89 @@ private class CoveoCommerceSetupControllerTest {
     );
   }
 
+  @IsTest
+  static void testPreviewCatalogJobDraft_validatesMissingCoreInputsAndDefaultWarnings() {
+    Test.startTest();
+    Map<String, Object> result = CoveoCommerceSetupController.previewCatalogJobDraft(
+      '',
+      '',
+      '',
+      '',
+      null,
+      null,
+      null,
+      '',
+      '',
+      'banana',
+      null,
+      null
+    );
+    Test.stopTest();
+
+    System.assertEquals(
+      false,
+      result.get('isReady'),
+      'Preview should fail readiness when required core inputs are missing'
+    );
+    System.assertEquals(
+      CatalogBuyerGroupAvailabilityMode.DISABLED,
+      result.get('buyerGroupAvailabilityMode'),
+      'Unsupported modes should normalize back to Disabled in the preview response'
+    );
+    System.assertEquals(
+      0,
+      result.get('selectedFieldCount'),
+      'Null additional fields should normalize to zero selections'
+    );
+    System.assertEquals(
+      0,
+      result.get('estimatedProductCount'),
+      'Blank inputs should estimate zero active products in isolated test context'
+    );
+
+    List<Object> validationMessages = (List<Object>) result.get(
+      'validationMessages'
+    );
+    String combinedValidations = String.join(
+      new List<String>{
+        String.valueOf(validationMessages[0]),
+        String.valueOf(validationMessages[1]),
+        String.valueOf(validationMessages[2]),
+        String.valueOf(validationMessages[3]),
+        String.valueOf(validationMessages[4]),
+        String.valueOf(validationMessages[5])
+      },
+      ' '
+    );
+
+    System.assert(
+      combinedValidations.contains('Job label is required') &&
+      combinedValidations.contains('Developer Name is required') &&
+      combinedValidations.contains('Coveo Org Id is required') &&
+      combinedValidations.contains('Product Source Id is required') &&
+      combinedValidations.contains('Locale is required') &&
+      combinedValidations.contains('Buyer Group Availability Mode must be'),
+      'Preview should return the full validation summary for missing core fields and unsupported modes'
+    );
+
+    List<Object> warningMessages = (List<Object>) result.get('warningMessages');
+    String combinedWarnings = String.join(
+      new List<String>{
+        String.valueOf(warningMessages[0]),
+        String.valueOf(warningMessages[1]),
+        String.valueOf(warningMessages[2])
+      },
+      ' '
+    );
+
+    System.assert(
+      combinedWarnings.contains('No catalog is selected') &&
+      combinedWarnings.contains('global default builder') &&
+      combinedWarnings.contains('zero active products'),
+      'Preview should surface default non-blocking warnings for blank catalog, builder, and empty scope'
+    );
+  }
+
   // ============================================================
   // Tests for getActiveBuilderMapping()
   // ============================================================

--- a/force-app/main/default/classes/SafeFieldUtilTest.cls
+++ b/force-app/main/default/classes/SafeFieldUtilTest.cls
@@ -66,4 +66,37 @@ private class SafeFieldUtilTest {
       'Blank field API name should return null'
     );
   }
+
+  @IsTest
+  static void testSafeGet_handlesUnqueriedFieldsAndTypedHelpers() {
+    Account account = new Account(Name = 'Coverage Account', AnnualRevenue = 42);
+    insert account;
+
+    Account queriedAccount = [
+      SELECT Id
+      FROM Account
+      WHERE Id = :account.Id
+    ];
+
+    System.assertEquals(
+      account.Id,
+      SafeFieldUtil.safeGetId(queriedAccount, 'Id'),
+      'Queried Id fields should be returned through the typed helper'
+    );
+    System.assertEquals(
+      null,
+      SafeFieldUtil.safeGetString(queriedAccount, 'Name'),
+      'Unqueried fields should return null instead of surfacing SObject access exceptions'
+    );
+
+    Account inMemoryAccount = new Account(
+      Name = 'Revenue Account',
+      AnnualRevenue = 99
+    );
+    System.assertEquals(
+      99,
+      SafeFieldUtil.safeGetDecimal(inMemoryAccount, 'AnnualRevenue'),
+      'Decimal helpers should return in-memory field values when present'
+    );
+  }
 }


### PR DESCRIPTION
## Summary
Add dedicated coverage for `CatalogBuyerGroupEntitlementProvider` to unblock unlocked package promotion, and make the release workflow fail immediately when Salesforce reports that the package-level coverage gate did not pass.

## Why
The April 1, 2026 `Release Unlocked Package` run on `main` at `bcabee9` created package version `04tak000000PZiXAAW`, but Salesforce reported `CodeCoverage: 73` and `HasPassedCodeCoverageCheck: false`, which caused promotion to fail.

The main gap was the new embedded Buyer Group entitlement provider introduced in PR #52. In the scratch org aggregate, that class was only partially covered, while the rest of the new package classes were already in much better shape.

The workflow also only surfaced the problem at promotion time. Reading `HasPassedCodeCoverageCheck` earlier gives us a clearer failure mode for both dry runs and real releases.

## What changed
- Added `CatalogBuyerGroupEntitlementProviderTest`
- Covered the provider's empty-input and missing-relationship exits
- Covered store-without-buyer-groups and buyer-group-without-policies cases
- Covered visible-vs-hidden entitlement policy filtering and product-level access resolution
- Verified products without resolved `ec_product_id` values are ignored by the provider
- Updated `release-unlocked-package.yml` to log `CodeCoverage` and `HasPassedCodeCoverageCheck`
- Updated `release-unlocked-package.yml` to fail immediately when Salesforce reports that the package coverage gate did not pass

## Validation
- Deployed the new test class to `ccetl`
- Ran `CatalogBuyerGroupEntitlementProviderTest` with code coverage in `ccetl`
- Result: 4/4 tests passing
- Result: `CatalogBuyerGroupEntitlementProvider` at 96% coverage in `ccetl`
- Triggered a dry-run `Release Unlocked Package` workflow on this branch to validate the real packaging path before merge

## Follow-up
- Merge this PR
- Review the in-flight dry-run workflow result on `codex/fix-unlocked-package-coverage`
- Re-run the `Release Unlocked Package` workflow for version `1.2.2`
