### PR TITLE
[codex] Reduce embedded access stream throttling

### DIFF
--- a/force-app/main/default/classes/CoveoApiUtilityTest.cls
+++ b/force-app/main/default/classes/CoveoApiUtilityTest.cls
@@ -6,11 +6,22 @@ private class CoveoApiUtilityTest {
     Integer statusCode;
     String status;
     String body;
+    Map<String, String> headers;
 
     MockResponse(Integer statusCode, String status, String body) {
+      this(statusCode, status, body, null);
+    }
+
+    MockResponse(
+      Integer statusCode,
+      String status,
+      String body,
+      Map<String, String> headers
+    ) {
       this.statusCode = statusCode;
       this.status = status;
       this.body = body;
+      this.headers = headers == null ? new Map<String, String>() : headers;
     }
   }
 
@@ -31,6 +42,9 @@ private class CoveoApiUtilityTest {
           res.setStatusCode(config.statusCode);
           res.setStatus(config.status);
           res.setBody(config.body);
+          for (String headerName : config.headers.keySet()) {
+            res.setHeader(headerName, config.headers.get(headerName));
+          }
           return res;
         }
       }
@@ -229,6 +243,49 @@ private class CoveoApiUtilityTest {
       System.assert(e.getMessage().contains('retry later'));
     }
     System.assertEquals(true, deleteFailed);
+  }
+
+  @IsTest
+  static void testStreamClientThrottleError_includesRetryAndBatchGuidance() {
+    Test.setMock(
+      HttpCalloutMock.class,
+      new RecordingHttpMock(
+        new Map<String, MockResponse>{
+          '/stream/update' => new MockResponse(
+            400,
+            '400 Bad Request',
+            '{"errorCode":"ORGANIZATION_IS_THROTTLED","message":"STREAM_API_BURST_LIMIT_REACHED"}',
+            new Map<String, String>{ 'Retry-After' => '3' }
+          )
+        }
+      )
+    );
+
+    CoveoStreamClient client = new CoveoStreamClient('org-123', 'source-456');
+
+    Boolean updateFailed = false;
+    try {
+      client.streamUpdate('file-123');
+    } catch (CalloutException e) {
+      updateFailed = true;
+      System.assert(
+        e
+          .getMessage()
+          .contains('ORGANIZATION_IS_THROTTLED'),
+        'The raw throttle error should remain visible in the exception message'
+      );
+      System.assert(
+        e.getMessage().contains('Retry after 3 seconds.'),
+        'Throttle errors should surface the Retry-After header when provided'
+      );
+      System.assert(
+        e
+          .getMessage()
+          .contains('increase the embedded access batch size'),
+        'Throttle errors should guide operators toward the safer embedded access scope size'
+      );
+    }
+    System.assertEquals(true, updateFailed);
   }
 
   @IsTest

--- a/force-app/main/default/classes/CoveoStreamClient.cls
+++ b/force-app/main/default/classes/CoveoStreamClient.cls
@@ -47,16 +47,51 @@ public with sharing class CoveoStreamClient {
     return res.getBody();
   }
 
+  @TestVisible
+  private static Boolean isThrottleResponse(HttpResponse response) {
+    if (response == null) {
+      return false;
+    }
+
+    Integer statusCode = response.getStatusCode();
+    if (statusCode == 429) {
+      return true;
+    }
+
+    String body = response.getBody();
+    return String.isNotBlank(body) &&
+      (body.contains('ORGANIZATION_IS_THROTTLED') ||
+      body.contains('STREAM_API_BURST_LIMIT_REACHED'));
+  }
+
+  @TestVisible
+  private static String buildErrorMessage(HttpResponse response) {
+    String message =
+      'Coveo error: ' +
+      response.getStatus() +
+      ' ' +
+      response.getBody();
+
+    if (!isThrottleResponse(response)) {
+      return message;
+    }
+
+    String retryAfter = response == null ? null : response.getHeader('Retry-After');
+    if (String.isNotBlank(retryAfter)) {
+      message += ' Retry after ' + retryAfter.trim() + ' seconds.';
+    }
+
+    message +=
+      ' Coveo throttled this Stream API request. Reduce request frequency or increase the embedded access batch size to lower the number of /stream/update calls.';
+    return message;
+  }
+
   private void ensureOk(HttpResponse r) {
     if (r.getStatusCode() >= 300)
-      throw new CalloutException(
-        'Coveo error: ' + r.getStatus() + ' ' + r.getBody()
-      );
+      throw new CalloutException(buildErrorMessage(r));
   }
   private void ensureAccepted(HttpResponse r) {
     if (r.getStatusCode() >= 400)
-      throw new CalloutException(
-        'Coveo error: ' + r.getStatus() + ' ' + r.getBody()
-      );
+      throw new CalloutException(buildErrorMessage(r));
   }
 }

--- a/force-app/main/default/classes/EmbeddedBuyerGroupAccessExportBatch.cls
+++ b/force-app/main/default/classes/EmbeddedBuyerGroupAccessExportBatch.cls
@@ -1,4 +1,7 @@
 global with sharing class EmbeddedBuyerGroupAccessExportBatch implements Database.Batchable<SObject>, Database.AllowsCallouts {
+  @TestVisible private static final Integer DEFAULT_BATCH_SIZE = 1000;
+  @TestVisible private static final Integer MAX_BATCH_SIZE = 2000;
+
   private final CatalogJobConfig__mdt jobConfig;
 
   public EmbeddedBuyerGroupAccessExportBatch(String jobConfigDeveloperName) {
@@ -51,10 +54,17 @@ global with sharing class EmbeddedBuyerGroupAccessExportBatch implements Databas
   }
 
   public Integer getBatchSize() {
-    if (jobConfig.BatchSize__c != null) {
-      return Integer.valueOf(jobConfig.BatchSize__c);
-    }
-    return 50;
+    // Access-only syncs emit one Stream API update per batch scope. Use a much
+    // larger default and floor than the full product sync to avoid burst
+    // throttling on large catalogs, especially in non-production orgs.
+    Integer configuredBatchSize = jobConfig.BatchSize__c == null
+      ? DEFAULT_BATCH_SIZE
+      : Integer.valueOf(jobConfig.BatchSize__c);
+    Integer normalizedBatchSize = Math.max(
+      configuredBatchSize,
+      DEFAULT_BATCH_SIZE
+    );
+    return Math.min(normalizedBatchSize, MAX_BATCH_SIZE);
   }
 
   global Database.QueryLocator start(Database.BatchableContext bc) {

--- a/force-app/main/default/classes/EmbeddedBuyerGroupAccessExportBatchTest.cls
+++ b/force-app/main/default/classes/EmbeddedBuyerGroupAccessExportBatchTest.cls
@@ -65,6 +65,14 @@ private class EmbeddedBuyerGroupAccessExportBatchTest {
       Family = 'Hardware',
       IsActive = true
     );
+    if (
+      Product2.SObjectType
+        .getDescribe()
+        .fields.getMap()
+        .containsKey('Item_Number__c')
+    ) {
+      product.put('Item_Number__c', code);
+    }
     insert product;
     return product;
   }
@@ -172,6 +180,39 @@ private class EmbeddedBuyerGroupAccessExportBatchTest {
     System.assert(
       logs[0].Payload__c.contains('"sf_webstore_id"'),
       'Embedded access payloads should replace the Web Store field'
+    );
+  }
+
+  @IsTest
+  static void testGetBatchSize_usesLargeMinimumAndCapsAtPlatformMaximum() {
+    CatalogJobConfig__mdt belowMinimum = createConfig('CatalogJsonBuilderDefault');
+    belowMinimum.BatchSize__c = 20;
+    EmbeddedBuyerGroupAccessExportBatch normalizedBatch =
+      new EmbeddedBuyerGroupAccessExportBatch(belowMinimum);
+    System.assertEquals(
+      EmbeddedBuyerGroupAccessExportBatch.DEFAULT_BATCH_SIZE,
+      normalizedBatch.getBatchSize(),
+      'Embedded access syncs should clamp small batch sizes upward to reduce Stream API burst throttling'
+    );
+
+    CatalogJobConfig__mdt aboveMaximum = createConfig('CatalogJsonBuilderDefault');
+    aboveMaximum.BatchSize__c = 2500;
+    EmbeddedBuyerGroupAccessExportBatch cappedBatch =
+      new EmbeddedBuyerGroupAccessExportBatch(aboveMaximum);
+    System.assertEquals(
+      EmbeddedBuyerGroupAccessExportBatch.MAX_BATCH_SIZE,
+      cappedBatch.getBatchSize(),
+      'Embedded access syncs should respect the platform executeBatch maximum scope'
+    );
+
+    CatalogJobConfig__mdt defaultedConfig = createConfig('CatalogJsonBuilderDefault');
+    defaultedConfig.BatchSize__c = null;
+    EmbeddedBuyerGroupAccessExportBatch defaultedBatch =
+      new EmbeddedBuyerGroupAccessExportBatch(defaultedConfig);
+    System.assertEquals(
+      EmbeddedBuyerGroupAccessExportBatch.DEFAULT_BATCH_SIZE,
+      defaultedBatch.getBatchSize(),
+      'Embedded access syncs should default to the larger throttling-safe scope'
     );
   }
 }


### PR DESCRIPTION
## Summary
- reduce embedded Buyer Group access sync burst pressure on Coveo Stream API
- surface clearer throttle guidance, including `Retry-After`, when Coveo rejects a stream update
- harden the related Apex tests for orgs with extra `Product2` requirements

## Root Cause
Embedded `Run Access` performs one `/stream/update` request per batch execute scope. With small configured batch sizes, large catalogs were split into hundreds of execute scopes, which produced enough Stream API update calls to hit Coveo throttling (`ORGANIZATION_IS_THROTTLED` / `STREAM_API_BURST_LIMIT_REACHED`).

## What Changed
- clamp embedded access batch size to a safer range in `EmbeddedBuyerGroupAccessExportBatch`
  - default and minimum: `1000`
  - maximum: `2000`
- keep using the metadata `BatchSize__c`, but normalize it into that throttling-safe window for embedded access runs
- enrich `CoveoStreamClient` throttle failures with `Retry-After` and operator guidance
- add focused coverage for the new batch-size behavior and throttle message path
- make the embedded access test data resilient in orgs that require `Product2.Item_Number__c`

## Impact
- embedded `Run Access` should process the same catalog in far fewer batch executes
- that directly reduces the number of `/stream/update` requests sent to Coveo
- operators get a more actionable error message if Coveo still throttles a request

## Validation
- deployed the Apex changes to `geapp--bdcdev2`
- focused Apex tests passed: `CoveoApiUtilityTest`, `EmbeddedBuyerGroupAccessExportBatchTest` (`9/9`)
- observed behavior after the fix: embedded access sync batches dropped from `669` to `34` for the same catalog, which is the expected result of the larger execute scope
