### PR TITLE
Remove required sync state field permission

### DIFF
--- a/force-app/main/default/permissionsets/CoveoETL_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/CoveoETL_Admin.permissionset-meta.xml
@@ -142,11 +142,6 @@
         <field>Catalog_Sync_State__c.LastSuccessfulSyncAt__c</field>
         <readable>true</readable>
     </fieldPermissions>
-    <fieldPermissions>
-        <editable>true</editable>
-        <field>Catalog_Sync_State__c.ResolvedTargetKey__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
     <label>Coveo ETL Admin</label>
     <tabSettings>


### PR DESCRIPTION
## Summary
- remove field-level permissions for `Catalog_Sync_State__c.ResolvedTargetKey__c` from `CoveoETL_Admin`
- fix unlocked package version creation failing on a required field permission entry
- keep the rest of the sync state permissions unchanged

## Why
Package version creation is currently failing with:

`You cannot deploy to a required field: Catalog_Sync_State__c.ResolvedTargetKey__c`

Salesforce rejects permission-set field permissions on required fields during package creation, so this invalid entry blocks the package workflow.

## Validation
- validated the targeted deploy of `force-app/main/default/permissionsets/CoveoETL_Admin.permissionset-meta.xml`
- no source changes beyond removing the invalid permission entry
