### PR TITLE
adding support for selling model

### DIFF
--- a/force-app/main/default/classes/CatalogProductExportSupport.cls
+++ b/force-app/main/default/classes/CatalogProductExportSupport.cls
@@ -88,9 +88,11 @@ public with sharing class CatalogProductExportSupport {
         pricesByProduct.put(pricebookEntry.Product2Id, new Map<String, Decimal>());
       }
 
-      String priceKey = (pricebookEntry.Pricebook2Id == stdPricebookId)
-        ? ''
-        : (pricebookEntry.ProductSellingModelId == null) ? String.valueOf(pricebookEntry.Pricebook2Id) : String.valueOf(pricebookEntry.Pricebook2Id) + ':' + String.valueOf(pricebookEntry.ProductSellingModelId);
+      String priceKey = (pricebookEntry.ProductSellingModelId != null)
+        ? String.valueOf(pricebookEntry.Pricebook2Id) + ':' + String.valueOf(pricebookEntry.ProductSellingModelId)
+        : (pricebookEntry.Pricebook2Id == stdPricebookId)
+          ? ''
+          : String.valueOf(pricebookEntry.Pricebook2Id);
       pricesByProduct.get(pricebookEntry.Product2Id).put(
         priceKey,
         pricebookEntry.UnitPrice

--- a/force-app/main/default/classes/CatalogProductExportSupport.cls
+++ b/force-app/main/default/classes/CatalogProductExportSupport.cls
@@ -76,7 +76,7 @@ public with sharing class CatalogProductExportSupport {
     }
 
     for (PricebookEntry pricebookEntry : [
-      SELECT Id, Product2Id, Pricebook2Id, UnitPrice
+      SELECT Id, Product2Id, Pricebook2Id, UnitPrice, ProductSellingModelId
       FROM PricebookEntry
       WHERE Product2Id IN :scope AND IsActive = TRUE AND UnitPrice != NULL
     ]) {
@@ -90,7 +90,7 @@ public with sharing class CatalogProductExportSupport {
 
       String priceKey = (pricebookEntry.Pricebook2Id == stdPricebookId)
         ? ''
-        : String.valueOf(pricebookEntry.Pricebook2Id);
+        : (pricebookEntry.ProductSellingModelId == null) ? String.valueOf(pricebookEntry.Pricebook2Id) : String.valueOf(pricebookEntry.Pricebook2Id) + ':' + String.valueOf(pricebookEntry.ProductSellingModelId);
       pricesByProduct.get(pricebookEntry.Product2Id).put(
         priceKey,
         pricebookEntry.UnitPrice


### PR DESCRIPTION
Adding support for Selling Model

price key will contain

\<PriceBookId\> or \<PriceBookId\>:\<SellingModelId\> when selling model exist