### PR TITLE
[codex] Polish catalog job console and setup navigation

### DIFF
--- a/force-app/main/default/lwc/catalogJobConsole/catalogJobConsole.css
+++ b/force-app/main/default/lwc/catalogJobConsole/catalogJobConsole.css
@@ -135,6 +135,25 @@
   line-height: 1.45;
 }
 
+.cc-panel__header--workspace {
+  align-items: flex-start;
+}
+
+.cc-workspace-heading__title {
+  margin: 0.1rem 0 0;
+  color: #032d60;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.cc-workspace-heading__subtitle {
+  margin: 0.5rem 0 0;
+  color: #4f6791;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
 .cc-section-label {
   margin: 0;
   color: #54698d;
@@ -296,6 +315,12 @@
   background: #015fb2;
 }
 
+.cc-table-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
 .cc-config-card {
   border: 1px solid #d8dde6;
   border-radius: 1rem;
@@ -450,6 +475,12 @@
   background: #fff;
 }
 
+.cc-launchpad--workspace {
+  margin-top: 0;
+  border-color: #d7e3f1;
+  background: linear-gradient(180deg, #ffffff 0%, #fbfdff 100%);
+}
+
 .cc-launchpad__actions {
   display: flex;
   flex-wrap: wrap;
@@ -486,6 +517,234 @@
   color: #54698d;
   font-size: 0.82rem;
   line-height: 1.45;
+}
+
+.cc-workspace-shell {
+  margin-top: 1.25rem;
+}
+
+.cc-workspace-tab-panel {
+  margin-top: 1rem;
+}
+
+.cc-workspace-status-band {
+  padding: 1rem;
+  border: 1px solid #dbe5f0;
+  border-radius: 1rem;
+  background: linear-gradient(180deg, #ffffff 0%, #f9fbff 100%);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.cc-workspace-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.cc-summary-card {
+  border: 1px solid #dfe7f2;
+  border-radius: 1rem;
+  background: #fff;
+  padding: 1rem 1.05rem;
+}
+
+.cc-summary-card__eyebrow,
+.cc-metric-card__label,
+.cc-details-row__label,
+.cc-summary-card__line-label {
+  color: #5c7398;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.cc-summary-card__title {
+  margin: 0.2rem 0 0;
+  color: #0f3b76;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.cc-summary-card__summary {
+  margin: 0.55rem 0 0;
+  color: #16325c;
+  font-size: 1.02rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.cc-summary-card__line {
+  margin: 0.4rem 0 0;
+  color: #4f6791;
+  line-height: 1.45;
+}
+
+.cc-summary-card__meta {
+  margin: 0.55rem 0 0;
+  color: #54698d;
+  font-size: 0.83rem;
+  line-height: 1.45;
+}
+
+.cc-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin-top: 0.9rem;
+}
+
+.cc-metric-card {
+  border: 1px solid #dfe7f2;
+  border-radius: 0.95rem;
+  background: #fff;
+  padding: 0.95rem 1rem;
+}
+
+.cc-metric-card__value {
+  margin: 0.35rem 0 0;
+  color: #10386f;
+  font-size: 1.7rem;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.cc-metric-card__meta {
+  margin: 0.35rem 0 0;
+  color: #54698d;
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.cc-workspace-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 1rem;
+}
+
+.cc-workspace-nav__button {
+  border: 1px solid #d7e1ef;
+  border-radius: 999px;
+  background: #fff;
+  color: #42648e;
+  cursor: pointer;
+  font-size: 0.88rem;
+  font-weight: 700;
+  padding: 0.52rem 0.95rem;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+.cc-workspace-nav__button:hover {
+  border-color: #7db2ff;
+  color: #0b5cab;
+}
+
+.cc-workspace-nav__button--active {
+  border-color: #0176d3;
+  background: #edf4ff;
+  box-shadow: 0 0 0 1px rgb(1 118 211 / 12%);
+  color: #0176d3;
+}
+
+.cc-workspace-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(18rem, 0.95fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.cc-workspace-grid__primary,
+.cc-workspace-grid__secondary {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cc-workspace-section {
+  border: 1px solid #dbe5f0;
+  border-radius: 1rem;
+  background: #fff;
+  padding: 1rem;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+
+.cc-table-action--full {
+  width: 100%;
+}
+
+.cc-download-card {
+  margin-top: 1rem;
+  border: 1px dashed #c6d9f4;
+  border-radius: 0.95rem;
+  background: linear-gradient(180deg, #ffffff 0%, #fbfdff 100%);
+  padding: 1rem;
+}
+
+.cc-download-card__title {
+  margin: 0;
+  color: #0f3b76;
+  font-size: 0.96rem;
+  font-weight: 700;
+}
+
+.cc-download-card__summary {
+  margin: 0.5rem 0 0;
+  color: #16325c;
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.cc-download-card__meta,
+.cc-download-card__supporting {
+  margin: 0.45rem 0 0;
+  color: #54698d;
+  line-height: 1.45;
+}
+
+.cc-download-card__actions {
+  margin-top: 0.9rem;
+}
+
+.cc-details-list {
+  margin-top: 1rem;
+}
+
+.cc-details-row + .cc-details-row {
+  margin-top: 0.8rem;
+}
+
+.cc-details-row {
+  display: grid;
+  grid-template-columns: minmax(10rem, 0.95fr) minmax(0, 1.35fr);
+  gap: 0.9rem;
+  align-items: start;
+  padding-top: 0.8rem;
+  border-top: 1px solid #eef2f7;
+}
+
+.cc-details-row:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.cc-details-row__value {
+  margin: 0;
+  color: #16325c;
+  line-height: 1.5;
+  word-break: break-word;
 }
 
 .cc-detail-grid {
@@ -533,6 +792,31 @@
   padding: 1rem;
 }
 
+.cc-run-card__header-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+
+.cc-run-card__download {
+  border: 1px solid #c9d8e6;
+  border-radius: 999px;
+  background: #fff;
+  color: #16325c;
+  cursor: pointer;
+  font-size: 0.76rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.42rem 0.68rem;
+  white-space: nowrap;
+}
+
+.cc-run-card__download:hover {
+  border-color: #0176d3;
+  background: #f8fbff;
+}
+
 .cc-run-card--complete {
   background: linear-gradient(180deg, #ffffff 0%, #f7fff9 100%);
 }
@@ -549,17 +833,17 @@
 }
 
 .cc-stage-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
-  gap: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
   margin-top: 1rem;
 }
 
 .cc-stage-card {
   border: 1px solid #e5ecf3;
   border-radius: 0.85rem;
-  background: #f8fafc;
-  padding: 0.85rem;
+  background: linear-gradient(180deg, #ffffff 0%, #fbfdff 100%);
+  padding: 0.95rem 1rem;
 }
 
 .cc-stage-card__actions {
@@ -567,6 +851,14 @@
   flex-direction: column;
   gap: 0.45rem;
   align-items: flex-end;
+}
+
+.cc-stage-card__summary {
+  margin: 0.35rem 0 0;
+  color: #16325c;
+  font-size: 0.92rem;
+  font-weight: 600;
+  line-height: 1.45;
 }
 
 .cc-stage-card__abort {
@@ -590,6 +882,20 @@
   color: #54698d;
   font-size: 0.82rem;
   line-height: 1.45;
+}
+
+.cc-stage-card__meta {
+  margin: 0.35rem 0 0;
+  color: #54698d;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.cc-stage-card__timing {
+  margin: 0.7rem 0 0;
+  color: #5c7398;
+  font-size: 0.8rem;
+  font-weight: 600;
 }
 
 .cc-activity-list {
@@ -648,6 +954,12 @@
   .cc-stat-grid {
     grid-template-columns: 1fr;
   }
+
+  .cc-workspace-grid,
+  .cc-workspace-summary-grid,
+  .cc-metric-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 768px) {
@@ -668,6 +980,11 @@
     justify-content: flex-start;
   }
 
+  .cc-run-card__header-actions,
+  .cc-stage-card__actions {
+    align-items: flex-start;
+  }
+
   .cc-launchpad__status {
     grid-template-columns: 1fr;
   }
@@ -675,6 +992,15 @@
   .cc-detail-grid,
   .cc-stage-list {
     grid-template-columns: 1fr;
+  }
+
+  .cc-workspace-heading__title {
+    font-size: 1.6rem;
+  }
+
+  .cc-details-row {
+    grid-template-columns: 1fr;
+    gap: 0.35rem;
   }
 
   .cc-config-table {

--- a/force-app/main/default/lwc/catalogJobConsole/catalogJobConsole.html
+++ b/force-app/main/default/lwc/catalogJobConsole/catalogJobConsole.html
@@ -100,7 +100,7 @@
                       <th scope="col">Product Scope</th>
                       <th scope="col">Buyer Group Access</th>
                       <th scope="col">Status</th>
-                      <th scope="col">Last Sync</th>
+                      <th scope="col">Latest Sync</th>
                       <th scope="col">Actions</th>
                     </tr>
                   </thead>
@@ -202,11 +202,15 @@
           </section>
 
           <section class="cc-panel cc-panel--workspace">
-            <div class="cc-panel__header">
-              <div>
+            <div class="cc-panel__header cc-panel__header--workspace">
+              <div class="cc-workspace-heading">
                 <p class="cc-section-label">Selected Config</p>
-                <h3 class="cc-panel__title">{selectedRunHeading}</h3>
-                <p class="cc-panel__meta">{selectedRunSubtitle}</p>
+                <h3 class="cc-workspace-heading__title">
+                  {selectedRunHeading}
+                </h3>
+                <p class="cc-workspace-heading__subtitle">
+                  {selectedRunSubtitle}
+                </p>
               </div>
               <template if:true={hasSelectedConfig}>
                 <div class="cc-badge-group">
@@ -224,186 +228,433 @@
             </div>
 
             <template if:true={hasSelectedConfig}>
-              <div class="cc-launchpad">
-                <div class="cc-launchpad__actions">
-                  <lightning-button
-                    label={selectedProductRunLabel}
-                    variant="brand"
-                    onclick={handleRunSelectedProducts}
-                    disabled={selectedConfig.productDisabled}
-                  ></lightning-button>
-                  <lightning-button
-                    label="Run Access"
-                    variant="neutral"
-                    onclick={handleRunSelectedAvailability}
-                    disabled={selectedConfig.availabilityDisabled}
-                  ></lightning-button>
-                  <template if:true={showRunSelectedBoth}>
+              <div class="cc-workspace-shell">
+                <div class="cc-launchpad cc-launchpad--workspace">
+                  <div class="cc-launchpad__actions">
                     <lightning-button
-                      label="Run Both"
-                      variant="brand-outline"
-                      onclick={handleRunSelectedBoth}
-                      disabled={selectedConfig.bothDisabled}
+                      label={selectedProductRunLabel}
+                      variant="brand"
+                      onclick={handleRunSelectedProducts}
+                      disabled={selectedConfig.productDisabled}
                     ></lightning-button>
-                  </template>
-                  <lightning-button
-                    label="Abort Product Run"
-                    variant="destructive-text"
-                    onclick={handleAbortSelectedProductRun}
-                    disabled={abortSelectedProductRunDisabled}
-                  ></lightning-button>
-                </div>
-                <div class="cc-launchpad__status">
-                  <span class={selectedConfigQuickStatusClass}>
-                    {selectedConfig.quickStatusLabel}
-                  </span>
-                  <div>
-                    <p class="cc-launchpad__status-summary">
-                      {selectedProductStatusSummary}
-                    </p>
-                    <p class="cc-launchpad__status-meta">
-                      {selectedProductStatusMeta}
-                    </p>
+                    <lightning-button
+                      label="Run Access"
+                      variant="neutral"
+                      onclick={handleRunSelectedAvailability}
+                      disabled={selectedConfig.availabilityDisabled}
+                    ></lightning-button>
+                    <template if:true={showRunSelectedBoth}>
+                      <lightning-button
+                        label="Run Both"
+                        variant="brand-outline"
+                        onclick={handleRunSelectedBoth}
+                        disabled={selectedConfig.bothDisabled}
+                      ></lightning-button>
+                    </template>
+                    <lightning-button
+                      label="Abort Product Run"
+                      variant="destructive-text"
+                      onclick={handleAbortSelectedProductRun}
+                      disabled={abortSelectedProductRunDisabled}
+                    ></lightning-button>
                   </div>
+                  <div class="cc-launchpad__status">
+                    <span class={selectedConfigQuickStatusClass}>
+                      {selectedConfig.quickStatusLabel}
+                    </span>
+                    <div>
+                      <p class="cc-launchpad__status-summary">
+                        {selectedProductStatusSummary}
+                      </p>
+                      <p class="cc-launchpad__status-meta">
+                        {selectedProductStatusMeta}
+                      </p>
+                    </div>
+                  </div>
+                  <template if:true={launchpadNote}>
+                    <p class="cc-launchpad__note">{launchpadNote}</p>
+                  </template>
                 </div>
-                <template if:true={launchpadNote}>
-                  <p class="cc-launchpad__note">{launchpadNote}</p>
-                </template>
-              </div>
 
-              <div class="cc-detail-grid">
-                <template for:each={selectedConfigFactRows} for:item="fact">
-                  <article key={fact.label} class="cc-detail-card">
-                    <p class="cc-detail-card__label">{fact.label}</p>
-                    <p class="cc-detail-card__value">{fact.value}</p>
-                  </article>
+                <div class="cc-workspace-nav">
+                  <template for:each={workspaceNavItems} for:item="item">
+                    <button
+                      key={item.value}
+                      type="button"
+                      class={item.className}
+                      data-focus={item.value}
+                      onclick={handleSelectWorkspaceFocus}
+                    >
+                      {item.label}
+                    </button>
+                  </template>
+                </div>
+
+                <template if:true={isWorkspaceStatusTab}>
+                  <div class="cc-workspace-tab-panel">
+                    <div class="cc-workspace-status-band">
+                      <div class="cc-workspace-summary-grid">
+                        <article class="cc-summary-card">
+                          <p class="cc-summary-card__eyebrow">Status</p>
+                          <h4 class="cc-summary-card__title">
+                            Current product status
+                          </h4>
+                          <p class="cc-summary-card__summary">
+                            {selectedProductStatusSummary}
+                          </p>
+                          <p class="cc-summary-card__line">
+                            {selectedProductStatusMeta}
+                          </p>
+                          <p class="cc-summary-card__meta">
+                            {selectedProductStatusFootnote}
+                          </p>
+                        </article>
+
+                        <article class="cc-summary-card">
+                          <p class="cc-summary-card__eyebrow">Baseline</p>
+                          <h4 class="cc-summary-card__title">
+                            Baseline clarity
+                          </h4>
+                          <template
+                            for:each={selectedBaselineClarityRows}
+                            for:item="row"
+                          >
+                            <p key={row.label} class="cc-summary-card__line">
+                              <span class="cc-summary-card__line-label">
+                                {row.label}:
+                              </span>
+                              {row.value}
+                            </p>
+                          </template>
+                        </article>
+                      </div>
+
+                      <div class="cc-metric-grid">
+                        <template
+                          for:each={selectedConfigMetricCards}
+                          for:item="metric"
+                        >
+                          <article key={metric.label} class="cc-metric-card">
+                            <p class="cc-metric-card__label">{metric.label}</p>
+                            <p class="cc-metric-card__value">{metric.value}</p>
+                            <p class="cc-metric-card__meta">{metric.meta}</p>
+                          </article>
+                        </template>
+                      </div>
+                    </div>
+                  </div>
+                </template>
+
+                <template if:true={isWorkspaceLiveRunsTab}>
+                  <div class="cc-workspace-tab-panel">
+                    <div class="cc-workspace-grid">
+                      <div class="cc-workspace-grid__primary">
+                        <section class="cc-workspace-section">
+                          <div class="cc-monitor__header">
+                            <div>
+                              <p class="cc-section-label">Live Runs</p>
+                              <h4 class="cc-monitor__title">Batch progress</h4>
+                            </div>
+                            <p class="cc-monitor__meta">
+                              {selectedConfigRunMonitorSubtitle}
+                            </p>
+                          </div>
+
+                          <template if:true={hasSelectedConfigRunSessions}>
+                            <div class="cc-run-list">
+                              <template
+                                for:each={selectedConfigRunSessions}
+                                for:item="run"
+                              >
+                                <article key={run.runKey} class={run.cardClass}>
+                                  <div class="cc-run-card__header">
+                                    <div>
+                                      <h5 class="cc-run-card__title">
+                                        {run.label}
+                                      </h5>
+                                      <p class="cc-run-card__meta">
+                                        {run.developerName} • Started
+                                        {run.launchedAtLabel}
+                                      </p>
+                                      <p class="cc-run-card__timing">
+                                        {run.timingLabel}
+                                      </p>
+                                    </div>
+                                    <div class="cc-run-card__header-actions">
+                                      <button
+                                        type="button"
+                                        class="cc-run-card__download"
+                                        data-run-key={run.runKey}
+                                        onclick={handleDownloadRunSummary}
+                                      >
+                                        Download Summary
+                                      </button>
+                                      <span class={run.overallStatusClass}>
+                                        {run.overallStatusLabel}
+                                      </span>
+                                    </div>
+                                  </div>
+
+                                  <lightning-progress-bar
+                                    value={run.progressPercent}
+                                    size="medium"
+                                  ></lightning-progress-bar>
+                                  <p class="cc-run-card__progress">
+                                    {run.progressPercent}% complete
+                                  </p>
+
+                                  <div class="cc-stage-list">
+                                    <template
+                                      for:each={run.stages}
+                                      for:item="stage"
+                                    >
+                                      <div
+                                        key={stage.jobId}
+                                        class="cc-stage-card"
+                                      >
+                                        <div class="cc-stage-card__header">
+                                          <div>
+                                            <p class="cc-stage-card__title">
+                                              {stage.label}
+                                            </p>
+                                            <p class="cc-stage-card__summary">
+                                              {stage.primaryDetail}
+                                            </p>
+                                            <template
+                                              if:true={stage.secondaryDetail}
+                                            >
+                                              <p class="cc-stage-card__meta">
+                                                {stage.secondaryDetail}
+                                              </p>
+                                            </template>
+                                          </div>
+                                          <div class="cc-stage-card__actions">
+                                            <span class={stage.statusClass}>
+                                              {stage.statusLabel}
+                                            </span>
+                                            <template if:true={stage.canAbort}>
+                                              <button
+                                                type="button"
+                                                class="cc-stage-card__abort"
+                                                data-job-id={stage.jobId}
+                                                data-job-label={stage.label}
+                                                onclick={handleAbortStage}
+                                              >
+                                                Abort
+                                              </button>
+                                            </template>
+                                          </div>
+                                        </div>
+                                        <template if:true={stage.timingLabel}>
+                                          <p class="cc-stage-card__timing">
+                                            {stage.timingLabel}
+                                          </p>
+                                        </template>
+                                      </div>
+                                    </template>
+                                  </div>
+                                </article>
+                              </template>
+                            </div>
+                          </template>
+                          <template if:false={hasSelectedConfigRunSessions}>
+                            <div class="cc-empty-state">
+                              Launch a sync from this configuration to populate
+                              the run monitor, or wait for the active Salesforce
+                              product job to appear here.
+                            </div>
+                          </template>
+                        </section>
+                      </div>
+
+                      <div class="cc-workspace-grid__secondary">
+                        <section class="cc-workspace-section">
+                          <div class="cc-monitor__header">
+                            <div>
+                              <p class="cc-section-label">Downloads</p>
+                              <h4 class="cc-monitor__title">Run outputs</h4>
+                            </div>
+                            <span class={selectedRunDownloadStatusClass}>
+                              {selectedRunDownloadStatusLabel}
+                            </span>
+                          </div>
+
+                          <div class="cc-download-card">
+                            <p class="cc-download-card__title">
+                              Latest run summary
+                            </p>
+                            <p class="cc-download-card__summary">
+                              {selectedRunDownloadSummary}
+                            </p>
+                            <p class="cc-download-card__meta">
+                              {selectedRunDownloadMeta}
+                            </p>
+                            <div class="cc-download-card__actions">
+                              <button
+                                type="button"
+                                class="cc-table-action cc-table-action--primary cc-table-action--full"
+                                onclick={handleDownloadSelectedRunSummary}
+                                disabled={selectedRunSummaryDownloadDisabled}
+                              >
+                                Download Latest Run Summary
+                              </button>
+                            </div>
+                            <p class="cc-download-card__supporting">
+                              Per-run summary downloads are also available
+                              directly on each tracked run card.
+                            </p>
+                          </div>
+
+                          <div class="cc-download-card">
+                            <p class="cc-download-card__title">
+                              Open Async Apex job
+                            </p>
+                            <p class="cc-download-card__summary">
+                              {selectedRunAsyncJobSummary}
+                            </p>
+                            <p class="cc-download-card__meta">
+                              {selectedRunAsyncJobMeta}
+                            </p>
+                            <div class="cc-download-card__actions">
+                              <button
+                                type="button"
+                                class="cc-table-action cc-table-action--full"
+                                onclick={handleOpenSelectedAsyncApexJob}
+                                disabled={selectedRunAsyncJobDisabled}
+                              >
+                                Open Apex Jobs in Setup
+                              </button>
+                            </div>
+                            <p class="cc-download-card__supporting">
+                              {selectedRunAsyncJobSupporting}
+                            </p>
+                          </div>
+                        </section>
+                      </div>
+                    </div>
+                  </div>
+                </template>
+
+                <template if:true={isWorkspaceActivityTab}>
+                  <div class="cc-workspace-tab-panel">
+                    <section class="cc-workspace-section">
+                      <div class="cc-monitor__header">
+                        <div>
+                          <p class="cc-section-label">Recent Activity</p>
+                          <h4 class="cc-monitor__title">Console timeline</h4>
+                        </div>
+                        <p class="cc-monitor__meta">
+                          Session-level activity across launches, detected
+                          active jobs, and status changes.
+                        </p>
+                      </div>
+
+                      <template if:true={hasActivityFeed}>
+                        <ul class="cc-activity-list">
+                          <template
+                            for:each={visibleActivityFeed}
+                            for:item="entry"
+                          >
+                            <li key={entry.key} class="cc-activity-item">
+                              <span class="cc-activity-item__time">
+                                {entry.timestampLabel}
+                              </span>
+                              <span class="cc-activity-item__message">
+                                {entry.message}
+                              </span>
+                            </li>
+                          </template>
+                        </ul>
+                      </template>
+                      <template if:false={hasActivityFeed}>
+                        <div class="cc-empty-state">
+                          Launch a run to start building the timeline.
+                        </div>
+                      </template>
+                    </section>
+                  </div>
+                </template>
+
+                <template if:true={isWorkspaceDetailsTab}>
+                  <div class="cc-workspace-tab-panel">
+                    <div class="cc-workspace-grid cc-workspace-grid--details">
+                      <div class="cc-workspace-grid__primary">
+                        <section class="cc-workspace-section">
+                          <div class="cc-monitor__header">
+                            <div>
+                              <p class="cc-section-label">Selected Details</p>
+                              <h4 class="cc-monitor__title">
+                                Configuration snapshot
+                              </h4>
+                            </div>
+                            <p class="cc-monitor__meta">
+                              Key launch, baseline, and source details for this
+                              selected configuration.
+                            </p>
+                          </div>
+
+                          <div class="cc-details-list">
+                            <template
+                              for:each={selectedWorkspaceDetailRows}
+                              for:item="detail"
+                            >
+                              <div key={detail.label} class="cc-details-row">
+                                <p class="cc-details-row__label">
+                                  {detail.label}
+                                </p>
+                                <p class="cc-details-row__value">
+                                  {detail.value}
+                                </p>
+                              </div>
+                            </template>
+                          </div>
+                        </section>
+                      </div>
+
+                      <div class="cc-workspace-grid__secondary">
+                        <section class="cc-workspace-section">
+                          <div class="cc-monitor__header">
+                            <div>
+                              <p class="cc-section-label">Additional Context</p>
+                              <h4 class="cc-monitor__title">
+                                Full config facts
+                              </h4>
+                            </div>
+                            <p class="cc-monitor__meta">
+                              Expanded sync, schedule, and metadata context for
+                              troubleshooting.
+                            </p>
+                          </div>
+
+                          <div class="cc-detail-grid cc-detail-grid--workspace">
+                            <template
+                              for:each={selectedConfigFactRows}
+                              for:item="fact"
+                            >
+                              <article key={fact.label} class="cc-detail-card">
+                                <p class="cc-detail-card__label">
+                                  {fact.label}
+                                </p>
+                                <p class="cc-detail-card__value">
+                                  {fact.value}
+                                </p>
+                              </article>
+                            </template>
+                          </div>
+                        </section>
+                      </div>
+                    </div>
+                  </div>
                 </template>
               </div>
             </template>
 
-            <div class="cc-monitor">
-              <div class="cc-monitor__header">
-                <div>
-                  <p class="cc-section-label">Live Runs</p>
-                  <h4 class="cc-monitor__title">Batch progress</h4>
-                </div>
-                <p class="cc-monitor__meta">{runMonitorSubtitle}</p>
+            <template if:false={hasSelectedConfig}>
+              <div class="cc-empty-state">
+                Choose a configuration from the inventory above to open the
+                selected-config workspace.
               </div>
-
-              <template if:true={hasRunSessions}>
-                <div class="cc-run-list">
-                  <template for:each={visibleRunSessions} for:item="run">
-                    <article key={run.runKey} class={run.cardClass}>
-                      <div class="cc-run-card__header">
-                        <div>
-                          <h5 class="cc-run-card__title">{run.label}</h5>
-                          <p class="cc-run-card__meta">
-                            {run.developerName} • Started {run.launchedAtLabel}
-                          </p>
-                          <p class="cc-run-card__timing">{run.timingLabel}</p>
-                        </div>
-                        <span class={run.overallStatusClass}>
-                          {run.overallStatusLabel}
-                        </span>
-                      </div>
-
-                      <lightning-progress-bar
-                        value={run.progressPercent}
-                        size="medium"
-                      ></lightning-progress-bar>
-                      <p class="cc-run-card__progress">
-                        {run.progressPercent}% complete
-                      </p>
-
-                      <div class="cc-stage-list">
-                        <template for:each={run.stages} for:item="stage">
-                          <div key={stage.jobId} class="cc-stage-card">
-                            <div class="cc-stage-card__header">
-                              <div>
-                                <p class="cc-stage-card__title">
-                                  {stage.label}
-                                </p>
-                                <p class="cc-stage-card__meta">
-                                  {stage.batchesLabel}
-                                </p>
-                                <template if:true={stage.timingLabel}>
-                                  <p class="cc-stage-card__timing">
-                                    {stage.timingLabel}
-                                  </p>
-                                </template>
-                              </div>
-                              <div class="cc-stage-card__actions">
-                                <span class={stage.statusClass}>
-                                  {stage.statusLabel}
-                                </span>
-                                <template if:true={stage.canAbort}>
-                                  <button
-                                    type="button"
-                                    class="cc-stage-card__abort"
-                                    data-job-id={stage.jobId}
-                                    data-job-label={stage.label}
-                                    onclick={handleAbortStage}
-                                  >
-                                    Abort
-                                  </button>
-                                </template>
-                              </div>
-                            </div>
-                            <lightning-progress-bar
-                              value={stage.progressPercent}
-                              size="x-small"
-                            ></lightning-progress-bar>
-                            <template if:true={stage.extendedStatus}>
-                              <p class="cc-stage-card__extended">
-                                {stage.extendedStatus}
-                              </p>
-                            </template>
-                          </div>
-                        </template>
-                      </div>
-                    </article>
-                  </template>
-                </div>
-              </template>
-              <template if:false={hasRunSessions}>
-                <div class="cc-empty-state">
-                  Launch a sync from the selected configuration to populate the
-                  run monitor.
-                </div>
-              </template>
-            </div>
-
-            <div class="cc-monitor cc-monitor--activity">
-              <div class="cc-monitor__header">
-                <div>
-                  <p class="cc-section-label">Recent Activity</p>
-                  <h4 class="cc-monitor__title">Console timeline</h4>
-                </div>
-                <p class="cc-monitor__meta">
-                  Session-level activity from launches and status changes.
-                </p>
-              </div>
-
-              <template if:true={hasActivityFeed}>
-                <ul class="cc-activity-list">
-                  <template for:each={visibleActivityFeed} for:item="entry">
-                    <li key={entry.key} class="cc-activity-item">
-                      <span class="cc-activity-item__time">
-                        {entry.timestampLabel}
-                      </span>
-                      <span class="cc-activity-item__message">
-                        {entry.message}
-                      </span>
-                    </li>
-                  </template>
-                </ul>
-              </template>
-              <template if:false={hasActivityFeed}>
-                <div class="cc-empty-state">
-                  Launch a run to start building the timeline.
-                </div>
-              </template>
-            </div>
+            </template>
           </section>
         </div>
       </template>

--- a/force-app/main/default/lwc/catalogJobConsole/catalogJobConsole.js
+++ b/force-app/main/default/lwc/catalogJobConsole/catalogJobConsole.js
@@ -1,4 +1,5 @@
 import { LightningElement, wire } from "lwc";
+import { NavigationMixin } from "lightning/navigation";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
 import { refreshApex } from "@salesforce/apex";
 
@@ -17,8 +18,10 @@ const POLL_INTERVAL_MS = 4000;
 const CONFIG_REFRESH_INTERVAL_MS = 15000;
 const RUN_STORAGE_KEY = "catalogJobConsoleRuns:v1";
 const ACTIVITY_STORAGE_KEY = "catalogJobConsoleActivity:v1";
-const MAX_RUNS = 8;
+const MAX_RUNS = 24;
+const MAX_VISIBLE_COMPLETED_RUNS_PER_CONFIG = 3;
 const MAX_ACTIVITY_ITEMS = 18;
+const ASYNC_APEX_JOBS_SETUP_URL = "/lightning/setup/AsyncApexJobs/home";
 const BUYER_GROUP_MODE_DISABLED = "Disabled";
 const BUYER_GROUP_MODE_PAIRED = "PairedSource";
 const BUYER_GROUP_MODE_EMBEDDED = "Embedded";
@@ -85,10 +88,13 @@ function formatBuyerGroupAvailabilityMode(mode) {
   }
 }
 
-export default class CatalogJobConsole extends LightningElement {
+export default class CatalogJobConsole extends NavigationMixin(
+  LightningElement
+) {
   configs;
   error;
   selectedConfigId;
+  workspaceFocus = "status";
   runSessions = [];
   activityFeed = [];
   pollTimerId;
@@ -122,6 +128,7 @@ export default class CatalogJobConsole extends LightningElement {
         this.decorateConfig(config, nextSelectedId)
       );
       this.selectedConfigId = this.configs.length ? nextSelectedId : null;
+      this.reconcileTrackedProductRuns();
       this.error = undefined;
     } else if (error) {
       this.error = error;
@@ -232,6 +239,62 @@ export default class CatalogJobConsole extends LightningElement {
     return this.runSessions.length > 0;
   }
 
+  get selectedConfigMatchedRunSessions() {
+    if (!this.selectedConfig) {
+      return [];
+    }
+
+    return this.runSessions
+      .filter((runSession) => this.runMatchesSelectedConfig(runSession))
+      .sort(
+        (left, right) =>
+          this.getRunSessionSortTime(right) - this.getRunSessionSortTime(left)
+      );
+  }
+
+  get selectedConfigRunSessions() {
+    const matchingRuns = this.selectedConfigMatchedRunSessions;
+    const activeRuns = matchingRuns.filter(
+      (runSession) => !runSession.isTerminal
+    );
+    const terminalRuns = matchingRuns.filter(
+      (runSession) => runSession.isTerminal
+    );
+
+    return [
+      ...activeRuns,
+      ...terminalRuns.slice(0, MAX_VISIBLE_COMPLETED_RUNS_PER_CONFIG)
+    ];
+  }
+
+  get hasSelectedConfigRunSessions() {
+    return this.selectedConfigRunSessions.length > 0;
+  }
+
+  get selectedConfigLatestRun() {
+    return this.selectedConfigMatchedRunSessions[0] || null;
+  }
+
+  get selectedConfigLiveRunCount() {
+    return this.selectedConfigMatchedRunSessions.filter(
+      (session) => !session.isTerminal
+    ).length;
+  }
+
+  get selectedConfigTerminalRunCount() {
+    return this.selectedConfigMatchedRunSessions.filter(
+      (session) => session.isTerminal
+    ).length;
+  }
+
+  get selectedConfigHiddenTerminalRunCount() {
+    return Math.max(
+      0,
+      this.selectedConfigTerminalRunCount -
+        MAX_VISIBLE_COMPLETED_RUNS_PER_CONFIG
+    );
+  }
+
   get visibleRunSessions() {
     return this.runSessions.slice(0, MAX_RUNS);
   }
@@ -280,7 +343,7 @@ export default class CatalogJobConsole extends LightningElement {
         value: this.selectedConfig.deltaStatusDetail
       },
       {
-        label: "Baseline Full",
+        label: "Baseline Full Config",
         value: this.selectedConfig.baselineFullConfigLabel
       },
       {
@@ -320,11 +383,11 @@ export default class CatalogJobConsole extends LightningElement {
         value: this.selectedConfig.extraFieldsSummary
       },
       {
-        label: "Last Full Sync",
+        label: "Last Successful Full Baseline",
         value: this.selectedConfig.lastSuccessfulFullSyncLabel
       },
       {
-        label: "Last Successful Sync",
+        label: "Latest Successful Sync",
         value: this.selectedConfig.lastSuccessfulSyncLabel
       },
       {
@@ -338,16 +401,144 @@ export default class CatalogJobConsole extends LightningElement {
     ];
   }
 
+  get selectedBaselineClarityRows() {
+    if (!this.selectedConfig) {
+      return [];
+    }
+
+    return [
+      {
+        label: "Latest successful sync",
+        value: this.selectedConfig.lastSuccessfulSyncLabel
+      },
+      {
+        label: "Last successful full baseline",
+        value: this.selectedConfig.lastSuccessfulFullSyncLabel
+      },
+      {
+        label: "Baseline full config",
+        value: this.selectedConfig.baselineFullConfigLabel
+      }
+    ];
+  }
+
+  get selectedConfigMetricCards() {
+    if (!this.selectedConfig) {
+      return [];
+    }
+
+    const latestRun = this.selectedConfigLatestRun;
+    const liveRunCount = this.selectedConfigLiveRunCount;
+
+    return [
+      {
+        label: "Latest Successful Sync",
+        value: this.formatMetricMoment(
+          this.selectedConfig.lastSuccessfulSyncAt,
+          "Never"
+        ),
+        meta: this.selectedConfig.lastSuccessfulSyncLabel
+      },
+      {
+        label: "Last Full Baseline",
+        value: this.formatMetricDate(
+          this.selectedConfig.lastSuccessfulFullSyncAt,
+          "Never"
+        ),
+        meta: this.selectedConfig.lastSuccessfulFullSyncLabel
+      },
+      {
+        label: "Tracked Product Job",
+        value:
+          liveRunCount > 0
+            ? `${liveRunCount} live`
+            : latestRun
+              ? "Recent only"
+              : "No runs",
+        meta: this.getTrackedProductJobMeta(latestRun)
+      }
+    ];
+  }
+
+  get workspaceNavItems() {
+    return [
+      {
+        value: "status",
+        label: "Status",
+        className: this.getWorkspaceNavClass("status")
+      },
+      {
+        value: "liveRuns",
+        label: "Live Runs",
+        className: this.getWorkspaceNavClass("liveRuns")
+      },
+      {
+        value: "activity",
+        label: "Activity",
+        className: this.getWorkspaceNavClass("activity")
+      },
+      {
+        value: "details",
+        label: "Details",
+        className: this.getWorkspaceNavClass("details")
+      }
+    ];
+  }
+
+  get isWorkspaceStatusTab() {
+    return this.workspaceFocus === "status";
+  }
+
+  get isWorkspaceLiveRunsTab() {
+    return this.workspaceFocus === "liveRuns";
+  }
+
+  get isWorkspaceActivityTab() {
+    return this.workspaceFocus === "activity";
+  }
+
+  get isWorkspaceDetailsTab() {
+    return this.workspaceFocus === "details";
+  }
+
+  get selectedConfigRunMonitorSubtitle() {
+    if (!this.selectedConfig) {
+      return "Choose a configuration to start monitoring targeted runs.";
+    }
+
+    if (!this.hasSelectedConfigRunSessions) {
+      return "No tracked runs for this configuration yet. Launch one here, or wait for an active Salesforce product job to appear.";
+    }
+
+    if (this.selectedConfigLiveRunCount > 0) {
+      const hiddenCount = this.selectedConfigHiddenTerminalRunCount;
+      return hiddenCount > 0
+        ? `Showing all active runs plus ${MAX_VISIBLE_COMPLETED_RUNS_PER_CONFIG} recent completed runs. ${hiddenCount} older completed run${
+            hiddenCount === 1 ? " is" : "s are"
+          } hidden to keep this view focused.`
+        : "Showing all active runs for the selected configuration. Auto-refreshing every 4 seconds while they are in progress.";
+    }
+
+    if (this.selectedConfigHiddenTerminalRunCount > 0) {
+      const hiddenCount = this.selectedConfigHiddenTerminalRunCount;
+      return `Showing ${MAX_VISIBLE_COMPLETED_RUNS_PER_CONFIG} recent completed runs for this configuration. ${hiddenCount} older completed run${
+        hiddenCount === 1 ? " is" : "s are"
+      } hidden to keep this view focused.`;
+    }
+
+    return "Showing recent tracked runs for the selected configuration.";
+  }
+
   get runMonitorSubtitle() {
     if (!this.hasRunSessions) {
-      return "Launch a sync to start tracking live batch progress here.";
+      return "Launch a sync here, or wait for an active Salesforce product job to appear.";
     }
 
     if (this.hasIncompleteRuns) {
       return "Auto-refreshing every 4 seconds while active runs are in progress.";
     }
 
-    return "Recent run history from this console session.";
+    return "Recent run history from this console session, plus active product jobs detected in Salesforce.";
   }
 
   get selectedRunHeading() {
@@ -394,6 +585,133 @@ export default class CatalogJobConsole extends LightningElement {
     return this.selectedConfig?.quickStatusMeta || "Manual launch only";
   }
 
+  get selectedProductStatusFootnote() {
+    if (!this.selectedConfig) {
+      return "";
+    }
+
+    return this.selectedConfig.lastSuccessfulSyncLabel === "Never"
+      ? "No successful product sync has been recorded yet."
+      : `Latest successful sync: ${this.selectedConfig.lastSuccessfulSyncLabel}`;
+  }
+
+  get selectedRunDownloadStatusLabel() {
+    return this.selectedConfigLatestRun ? "Ready" : "Waiting";
+  }
+
+  get selectedRunDownloadStatusClass() {
+    return this.selectedConfigLatestRun
+      ? "cc-badge cc-badge--success"
+      : "cc-badge cc-badge--neutral";
+  }
+
+  get selectedRunSummaryDownloadDisabled() {
+    return !this.selectedConfigLatestRun;
+  }
+
+  get selectedRunDownloadSummary() {
+    const latestRun = this.selectedConfigLatestRun;
+    if (!latestRun) {
+      return "No tracked run summary is available yet for this configuration.";
+    }
+
+    return `${latestRun.overallStatusLabel} • Started ${latestRun.launchedAtLabel}`;
+  }
+
+  get selectedRunDownloadMeta() {
+    if (!this.selectedConfigLatestRun) {
+      return "Launch a sync from this workspace, or wait for an active Salesforce product job to seed the latest run summary here.";
+    }
+
+    return "Download a JSON snapshot for the latest tracked run, including job stages, status, progress, and timing.";
+  }
+
+  get selectedRunPrimaryStage() {
+    const latestRun = this.selectedConfigLatestRun;
+    if (!latestRun) {
+      return null;
+    }
+
+    const stages = latestRun.stages || latestRun.jobs || [];
+    return (
+      stages.find((stage) => stage.channel === "products" && stage.jobId) ||
+      stages.find((stage) => stage.jobId) ||
+      null
+    );
+  }
+
+  get selectedRunAsyncJobId() {
+    return this.selectedRunPrimaryStage?.jobId || "";
+  }
+
+  get selectedRunAsyncJobDisabled() {
+    return !this.selectedRunAsyncJobId;
+  }
+
+  get selectedRunAsyncJobSummary() {
+    const stage = this.selectedRunPrimaryStage;
+    if (!stage) {
+      return "No tracked Async Apex job is available yet for this configuration.";
+    }
+
+    return `${stage.label} • Job ${stage.jobId}`;
+  }
+
+  get selectedRunAsyncJobMeta() {
+    if (!this.selectedRunPrimaryStage) {
+      return "Launch a sync here, or wait for an active Salesforce product job to seed the latest job reference.";
+    }
+
+    return "Open Salesforce Setup with Apex Jobs so the latest tracked platform job is easy to inspect when deeper troubleshooting is needed.";
+  }
+
+  get selectedRunAsyncJobSupporting() {
+    return this.selectedRunAsyncJobId
+      ? "The latest tracked job ID stays visible here so it is quick to cross-check inside Salesforce Setup."
+      : "The latest tracked job ID will appear here as soon as this configuration has an active or recent run.";
+  }
+
+  get selectedWorkspaceDetailRows() {
+    if (!this.selectedConfig) {
+      return [];
+    }
+
+    return [
+      {
+        label: "Baseline Full Config",
+        value: this.selectedConfig.baselineFullConfigLabel
+      },
+      {
+        label: "Product Source",
+        value: this.selectedConfig.productSourceLabel
+      },
+      {
+        label: "Availability Source",
+        value: this.selectedConfig.availabilitySourceLabel
+      },
+      {
+        label: "Access Mode",
+        value: this.selectedConfig.buyerGroupAvailabilityModeLabel
+      },
+      {
+        label: "Web Store",
+        value: this.selectedConfig.webStoreLabel
+      },
+      {
+        label: "Scope",
+        value: this.selectedConfig.scopeSummary
+      },
+      {
+        label: "Schedule",
+        value: this.selectedConfig.scheduleSummary
+      },
+      {
+        label: "Extra Fields",
+        value: this.selectedConfig.extraFieldsSummary
+      }
+    ];
+  }
+
   get canAbortSelectedProductRun() {
     return this.selectedConfig?.canAbortCurrentProductRun === true;
   }
@@ -424,9 +742,19 @@ export default class CatalogJobConsole extends LightningElement {
     }
 
     this.selectedConfigId = configId;
+    this.workspaceFocus = "status";
     this.configs = this.configs.map((config) =>
       this.decorateConfig(config, this.selectedConfigId)
     );
+  }
+
+  handleSelectWorkspaceFocus(event) {
+    const focus = event.currentTarget?.dataset?.focus;
+    if (!focus) {
+      return;
+    }
+
+    this.workspaceFocus = focus;
   }
 
   async handleRunSelectedProducts() {
@@ -538,6 +866,81 @@ export default class CatalogJobConsole extends LightningElement {
     );
   }
 
+  handleDownloadRunSummary(event) {
+    const runKey = event.currentTarget?.dataset?.runKey;
+    if (!runKey) {
+      return;
+    }
+
+    this.downloadRunSummaryByKey(runKey);
+  }
+
+  handleDownloadSelectedRunSummary() {
+    const runKey = this.selectedConfigLatestRun?.runKey;
+    if (!runKey) {
+      this.showToast(
+        "Run unavailable",
+        "There is no tracked run summary available yet for this configuration.",
+        "info"
+      );
+      return;
+    }
+
+    this.downloadRunSummaryByKey(runKey);
+  }
+
+  handleOpenSelectedAsyncApexJob() {
+    if (!this.selectedRunAsyncJobId) {
+      this.showToast(
+        "Job unavailable",
+        "There is no tracked Async Apex job available yet for this configuration.",
+        "info"
+      );
+      return;
+    }
+
+    this.navigateToSetupPage(ASYNC_APEX_JOBS_SETUP_URL);
+  }
+
+  downloadRunSummaryByKey(runKey) {
+    const runSession = this.runSessions.find((run) => run.runKey === runKey);
+    if (!runSession) {
+      this.showToast(
+        "Run unavailable",
+        "The selected run is no longer available in this console session.",
+        "warning"
+      );
+      return;
+    }
+
+    const decoratedRun = runSession.stages
+      ? runSession
+      : this.decorateRunSession(runSession);
+    const payload = this.buildRunSummaryExport(decoratedRun);
+
+    try {
+      const blob = new Blob([JSON.stringify(payload, null, 2)], {
+        type: "application/json"
+      });
+      const downloadUrl = URL.createObjectURL(blob);
+      const downloadLink = document.createElement("a");
+      downloadLink.href = downloadUrl;
+      downloadLink.download = this.buildRunSummaryFilename(decoratedRun);
+      document.body.appendChild(downloadLink);
+      downloadLink.click();
+      document.body.removeChild(downloadLink);
+      window.setTimeout(() => URL.revokeObjectURL(downloadUrl), 0);
+    } catch (error) {
+      this.showToast(
+        "Download failed",
+        "Unable to build the run summary.",
+        "error"
+      );
+      // eslint-disable-next-line no-console
+      console.error("Download run summary error", error);
+    }
+  }
+
   async launchRuns(requestFn, successMessage) {
     try {
       const response = await requestFn();
@@ -587,6 +990,7 @@ export default class CatalogJobConsole extends LightningElement {
       .slice(0, MAX_RUNS)
       .map((session) => this.decorateRunSession(session));
 
+    this.workspaceFocus = "liveRuns";
     this.persistRunState();
   }
 
@@ -596,6 +1000,7 @@ export default class CatalogJobConsole extends LightningElement {
       developerName: launch.developerName,
       label: launch.label,
       mode: launch.mode,
+      source: "sessionLaunch",
       availabilityEnabled: launch.availabilityEnabled,
       buyerGroupAvailabilityMode: launch.buyerGroupAvailabilityMode,
       launchedAt: launch.launchedAt,
@@ -616,6 +1021,118 @@ export default class CatalogJobConsole extends LightningElement {
         createdDate: launch.launchedAt,
         completedDate: null
       }))
+    };
+  }
+
+  reconcileTrackedProductRuns() {
+    if (!Array.isArray(this.configs) || !this.configs.length) {
+      return;
+    }
+
+    const configByDeveloperName = new Map(
+      this.configs.map((config) => [config.developerName, config])
+    );
+    const trackedConfigsByJobId = new Map();
+
+    this.configs.forEach((config) => {
+      if (
+        config.currentProductIsActive !== true ||
+        !config.currentProductJobId
+      ) {
+        return;
+      }
+
+      const ownerConfig =
+        configByDeveloperName.get(config.currentProductConfigDeveloperName) ||
+        config;
+
+      trackedConfigsByJobId.set(config.currentProductJobId, ownerConfig);
+    });
+
+    if (!trackedConfigsByJobId.size) {
+      return;
+    }
+
+    const knownJobIds = new Set();
+    this.runSessions.forEach((runSession) => {
+      (runSession.jobs || []).forEach((job) => {
+        if (job.jobId) {
+          knownJobIds.add(job.jobId);
+        }
+      });
+    });
+
+    const nextRuns = [];
+    trackedConfigsByJobId.forEach((config, jobId) => {
+      if (knownJobIds.has(jobId)) {
+        return;
+      }
+
+      knownJobIds.add(jobId);
+      nextRuns.push(this.createTrackedProductRunSession(config));
+    });
+
+    if (!nextRuns.length) {
+      return;
+    }
+
+    nextRuns.forEach((runSession) => {
+      const trackedJobId = runSession.jobs?.[0]?.jobId;
+      this.addActivity(
+        `${runSession.label}: tracking active Salesforce product job${
+          trackedJobId ? ` ${trackedJobId}` : ""
+        }`
+      );
+    });
+
+    this.runSessions = [...nextRuns, ...this.runSessions]
+      .slice(0, MAX_RUNS)
+      .map((session) => this.decorateRunSession(session));
+
+    this.persistRunState();
+    this.startPollingIfNeeded();
+  }
+
+  createTrackedProductRunSession(config) {
+    const runMode =
+      config.currentProductRunMode === SYNC_MODE_DELTA
+        ? SYNC_MODE_DELTA
+        : SYNC_MODE_FULL;
+    const launchedAt =
+      config.currentProductStartedAt || new Date().toISOString();
+
+    return {
+      runKey: `tracked-${config.currentProductJobId}`,
+      developerName:
+        config.currentProductConfigDeveloperName || config.developerName,
+      label: config.label,
+      mode: "products",
+      source: "trackedProductJob",
+      availabilityEnabled: config.buyerGroupAccessEnabled === true,
+      buyerGroupAvailabilityMode: config.buyerGroupAvailabilityMode,
+      launchedAt,
+      jobs: [
+        {
+          jobId: config.currentProductJobId,
+          channel: "products",
+          label:
+            runMode === SYNC_MODE_DELTA
+              ? "Delta Product Sync"
+              : "Full Product Sync",
+          impactedProductCount: undefined,
+          changedRootProductCount: undefined,
+          exportProductCount: undefined,
+          scopeSummary: "",
+          status: config.currentProductJobStatus || "Queued",
+          jobItemsProcessed: 0,
+          totalJobItems: 0,
+          numberOfErrors: 0,
+          extendedStatus: "",
+          isTerminal: false,
+          createdDate: launchedAt,
+          completedDate: null
+        }
+      ]
     };
   }
 
@@ -805,6 +1322,35 @@ export default class CatalogJobConsole extends LightningElement {
     }
   }
 
+  navigateToSetupPage(url) {
+    if (!url) {
+      return;
+    }
+
+    const pageReference = {
+      type: "standard__webPage",
+      attributes: {
+        url
+      }
+    };
+
+    this[NavigationMixin.GenerateUrl](pageReference)
+      .then((generatedUrl) => {
+        const openedWindow = window.open(
+          generatedUrl || url,
+          "_blank",
+          "noopener"
+        );
+
+        if (!openedWindow) {
+          this[NavigationMixin.Navigate](pageReference);
+        }
+      })
+      .catch(() => {
+        this[NavigationMixin.Navigate](pageReference);
+      });
+  }
+
   decorateConfig(config, selectedConfigId) {
     const filterText = this.normalizeText(
       config.ProductFilter__c,
@@ -974,7 +1520,7 @@ export default class CatalogJobConsole extends LightningElement {
         config.lastSuccessfulSyncAt,
         "Never"
       ),
-      inventoryLastSyncMeta: `Full baseline: ${this.formatOptionalTimestamp(
+      inventoryLastSyncMeta: `Last successful full baseline: ${this.formatOptionalTimestamp(
         config.lastSuccessfulFullSyncAt,
         "Never"
       )}`
@@ -1039,17 +1585,28 @@ export default class CatalogJobConsole extends LightningElement {
     const progressPercent = this.getJobProgressPercent(job);
     const scopeSummary = this.describeJobScope(job);
     const batchesLabel = this.describeJobBatches(job, status);
+    const primaryDetail = scopeSummary || job.extendedStatus || batchesLabel;
+    const secondaryDetail =
+      scopeSummary && batchesLabel && batchesLabel !== scopeSummary
+        ? batchesLabel
+        : "";
 
     return {
       ...job,
       status,
       progressPercent,
-      statusLabel: this.describeStageChange(job.channel, status),
+      statusLabel: this.describeStageStatusBadge(status),
       statusClass: this.getStageStatusClass(status),
       batchesLabel,
       extendedStatus: scopeSummary || job.extendedStatus || "",
+      primaryDetail,
+      secondaryDetail,
       timingLabel: this.describeStageDuration(job),
-      canAbort: !!job.jobId && status !== "Completed" && status !== "Failed" && status !== "Aborted"
+      canAbort:
+        !!job.jobId &&
+        status !== "Completed" &&
+        status !== "Failed" &&
+        status !== "Aborted"
     };
   }
 
@@ -1282,6 +1839,16 @@ export default class CatalogJobConsole extends LightningElement {
     }
   }
 
+  describeStageStatusBadge(status) {
+    switch (status) {
+      case "Holding":
+      case "Preparing":
+        return "Queued";
+      default:
+        return this.normalizeText(status, "Queued");
+    }
+  }
+
   describeQuickStatus(config, { syncMode, scheduleSummary }) {
     const currentStatus = config.currentProductJobStatus;
     const currentJobId = config.currentProductJobId;
@@ -1311,7 +1878,9 @@ export default class CatalogJobConsole extends LightningElement {
     }
 
     if (config.isScheduled === true) {
-      const scheduleStateLabel = this.describeScheduleState(config.scheduleState);
+      const scheduleStateLabel = this.describeScheduleState(
+        config.scheduleState
+      );
       return {
         summary: scheduleStateLabel,
         meta: scheduleSummary,
@@ -1494,6 +2063,38 @@ export default class CatalogJobConsole extends LightningElement {
       : "cc-config-card";
   }
 
+  getTrackedProductJobMeta(latestRun) {
+    if (this.selectedConfig?.currentProductIsActive === true) {
+      return this.selectedConfig.currentProductJobId
+        ? `Job ${this.selectedConfig.currentProductJobId}`
+        : "Active product job detected";
+    }
+
+    if (latestRun) {
+      return `Latest tracked run started ${latestRun.launchedAtLabel}`;
+    }
+
+    return "Waiting for launch";
+  }
+
+  getWorkspaceNavClass(focus) {
+    return focus === this.workspaceFocus
+      ? "cc-workspace-nav__button cc-workspace-nav__button--active"
+      : "cc-workspace-nav__button";
+  }
+
+  getRunSessionSortTime(runSession) {
+    return this.toTimestamp(runSession?.launchedAt) ?? 0;
+  }
+
+  runMatchesSelectedConfig(runSession) {
+    if (!this.selectedConfig || !runSession) {
+      return false;
+    }
+
+    return runSession.developerName === this.selectedConfig.developerName;
+  }
+
   splitCsv(value) {
     return (value || "")
       .split(",")
@@ -1503,6 +2104,125 @@ export default class CatalogJobConsole extends LightningElement {
 
   normalizeText(value, fallback) {
     return value && String(value).trim() ? value : fallback;
+  }
+
+  formatMetricMoment(isoValue, fallback) {
+    if (!isoValue) {
+      return fallback;
+    }
+
+    const date = new Date(isoValue);
+    if (Number.isNaN(date.getTime())) {
+      return fallback;
+    }
+
+    const now = new Date();
+    const sameDay = date.toDateString() === now.toDateString();
+
+    return new Intl.DateTimeFormat(undefined, {
+      ...(sameDay
+        ? {
+            hour: "numeric",
+            minute: "2-digit"
+          }
+        : {
+            month: "short",
+            day: "numeric"
+          })
+    }).format(date);
+  }
+
+  formatMetricDate(isoValue, fallback) {
+    if (!isoValue) {
+      return fallback;
+    }
+
+    const date = new Date(isoValue);
+    if (Number.isNaN(date.getTime())) {
+      return fallback;
+    }
+
+    return new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric"
+    }).format(date);
+  }
+
+  buildRunSummaryExport(runSession) {
+    return {
+      exportedAt: new Date().toISOString(),
+      runKey: runSession.runKey,
+      label: runSession.label,
+      developerName: runSession.developerName,
+      mode: runSession.mode,
+      source: runSession.source || "sessionLaunch",
+      availabilityEnabled: runSession.availabilityEnabled === true,
+      buyerGroupAvailabilityMode: runSession.buyerGroupAvailabilityMode || "",
+      launchedAt: runSession.launchedAt || null,
+      launchedAtLabel:
+        runSession.launchedAtLabel ||
+        this.formatTimestamp(runSession.launchedAt),
+      overallStatusLabel: runSession.overallStatusLabel || "",
+      progressPercent: runSession.progressPercent ?? null,
+      isTerminal: runSession.isTerminal === true,
+      jobs: (runSession.stages || runSession.jobs || []).map((job) => ({
+        jobId: job.jobId || "",
+        channel: job.channel || "",
+        label: job.label || "",
+        status: job.status || "",
+        statusLabel: job.statusLabel || "",
+        progressPercent: job.progressPercent ?? null,
+        jobItemsProcessed: job.jobItemsProcessed ?? null,
+        totalJobItems: job.totalJobItems ?? null,
+        numberOfErrors: job.numberOfErrors ?? null,
+        batchesLabel: job.batchesLabel || "",
+        extendedStatus: job.extendedStatus || "",
+        timingLabel: job.timingLabel || "",
+        impactedProductCount: job.impactedProductCount ?? null,
+        changedRootProductCount: job.changedRootProductCount ?? null,
+        exportProductCount: job.exportProductCount ?? null,
+        scopeSummary: job.scopeSummary || "",
+        createdDate: job.createdDate || null,
+        completedDate: job.completedDate || null
+      }))
+    };
+  }
+
+  buildRunSummaryFilename(runSession) {
+    const fileStem = this.sanitizeFileSegment(
+      runSession.developerName || runSession.label || "catalog-run"
+    );
+    const timestamp = this.buildFileTimestamp(
+      runSession.launchedAt || new Date().toISOString()
+    );
+    return `${fileStem}-${timestamp}.json`;
+  }
+
+  sanitizeFileSegment(value) {
+    return (
+      String(value || "catalog-run")
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "") || "catalog-run"
+    );
+  }
+
+  buildFileTimestamp(isoValue) {
+    const date = isoValue ? new Date(isoValue) : new Date();
+    if (Number.isNaN(date.getTime())) {
+      return "run-summary";
+    }
+
+    return [
+      date.getFullYear(),
+      this.padNumber(date.getMonth() + 1),
+      this.padNumber(date.getDate()),
+      "-",
+      this.padNumber(date.getHours()),
+      this.padNumber(date.getMinutes()),
+      this.padNumber(date.getSeconds())
+    ].join("");
   }
 
   toTimestamp(isoValue) {

--- a/force-app/main/default/lwc/coveoCommerceSetup/coveoCommerceSetup.html
+++ b/force-app/main/default/lwc/coveoCommerceSetup/coveoCommerceSetup.html
@@ -440,7 +440,7 @@
                             <th scope="col">Experience</th>
                             <th scope="col">Product Source</th>
                             <th scope="col">Buyer Group Access</th>
-                            <th scope="col">Last Sync</th>
+                            <th scope="col">Latest Sync</th>
                             <th scope="col">Actions</th>
                           </tr>
                         </thead>

--- a/force-app/main/default/lwc/coveoCommerceSetup/coveoCommerceSetup.js
+++ b/force-app/main/default/lwc/coveoCommerceSetup/coveoCommerceSetup.js
@@ -896,9 +896,9 @@ export default class CoveoCommerceSetup extends NavigationMixin(
       },
       {
         key: "lastSync",
-        label: "Last Successful Sync",
+        label: "Latest Successful Sync",
         value: lastSyncValue,
-        helper: `Last full baseline: ${lastFullSyncValue}`
+        helper: `Last successful full baseline: ${lastFullSyncValue}`
       },
       {
         key: "accessMode",
@@ -1272,11 +1272,11 @@ export default class CoveoCommerceSetup extends NavigationMixin(
   }
 
   handleOpenNamedCredentials() {
-    window.open(this.namedCredentialSetupUrl, "_blank");
+    this.navigateToSetupPage(this.namedCredentialSetupUrl);
   }
 
   handleOpenCustomMetadata() {
-    window.open(this.customMetadataSetupUrl, "_blank");
+    this.navigateToSetupPage(this.customMetadataSetupUrl);
   }
 
   handleCustomBuilderInputChange(event) {
@@ -1319,6 +1319,35 @@ export default class CoveoCommerceSetup extends NavigationMixin(
         apiName: "Catalog_Job_Console"
       }
     });
+  }
+
+  navigateToSetupPage(url) {
+    if (!url) {
+      return;
+    }
+
+    const pageReference = {
+      type: "standard__webPage",
+      attributes: {
+        url
+      }
+    };
+
+    this[NavigationMixin.GenerateUrl](pageReference)
+      .then((generatedUrl) => {
+        const openedWindow = window.open(
+          generatedUrl || url,
+          "_blank",
+          "noopener"
+        );
+
+        if (!openedWindow) {
+          this[NavigationMixin.Navigate](pageReference);
+        }
+      })
+      .catch(() => {
+        this[NavigationMixin.Navigate](pageReference);
+      });
   }
 
   handleWorkspaceSelect(event) {
@@ -1911,8 +1940,8 @@ export default class CoveoCommerceSetup extends NavigationMixin(
       lastSuccessfulFullSyncAt: config.lastSuccessfulFullSyncAt || "",
       lastSuccessfulSyncAt: config.lastSuccessfulSyncAt || "",
       lastSyncSummary: [
-        `Last full: ${this.formatOptionalTimestamp(config.lastSuccessfulFullSyncAt, "Never")}`,
-        `Last sync: ${this.formatOptionalTimestamp(config.lastSuccessfulSyncAt, "Never")}`
+        `Last full baseline: ${this.formatOptionalTimestamp(config.lastSuccessfulFullSyncAt, "Never")}`,
+        `Latest successful sync: ${this.formatOptionalTimestamp(config.lastSuccessfulSyncAt, "Never")}`
       ].join(" • "),
       isScheduled,
       scheduledJobName: config.scheduledJobName || "",
@@ -1988,7 +2017,7 @@ export default class CoveoCommerceSetup extends NavigationMixin(
         config.lastSuccessfulSyncAt,
         "Never"
       ),
-      inventoryLastSyncMeta: `Full baseline: ${this.formatOptionalTimestamp(
+      inventoryLastSyncMeta: `Last successful full baseline: ${this.formatOptionalTimestamp(
         config.lastSuccessfulFullSyncAt,
         "Never"
       )}`,


### PR DESCRIPTION
## What changed

This PR polishes the catalog job console and related setup navigation so troubleshooting and run monitoring are clearer inside Salesforce.

- clarifies `Latest successful sync` versus `Last successful full baseline` language in the console surfaces
- fixes the setup quick actions for opening Custom Metadata and the related setup destination
- refreshes the selected-config workspace with the tabbed status / live runs / activity / details layout
- keeps live runs focused by showing all active runs plus only the most recent completed runs for the selected config
- simplifies run-stage visuals so batch inspection uses one run-level progress bar with cleaner stage cards
- adds direct run-summary download actions and an `Open Async Apex job` drill-in from the run outputs rail
- seeds live-run visibility from org-detected active product jobs so a new user session can still see current activity

## Why it changed

The previous console mixed baseline information, launch controls, run monitoring, and troubleshooting context into one heavy view. It also relied too much on session-local state for live visibility and had broken setup shortcuts for metadata troubleshooting.

These changes make the console easier to scan during support cases, especially when validating delta readiness, baseline freshness, and current async job activity.

## Impact

- support and implementation teams can distinguish full-baseline timestamps from latest successful delta runs more confidently
- admins have working setup shortcuts again when validating metadata/configuration
- console users get a calmer live-run view with easier drill-in paths for summary export and Apex job follow-up

## Validation

- ran bundled Prettier on:
  - `force-app/main/default/lwc/catalogJobConsole/catalogJobConsole.css`
  - `force-app/main/default/lwc/catalogJobConsole/catalogJobConsole.html`
  - `force-app/main/default/lwc/catalogJobConsole/catalogJobConsole.js`
  - `force-app/main/default/lwc/coveoCommerceSetup/coveoCommerceSetup.html`
  - `force-app/main/default/lwc/coveoCommerceSetup/coveoCommerceSetup.js`
- ran `git diff --cached --check`

## Notes

- mockup/output artifacts remain uncommitted in the local worktree and are intentionally excluded from this PR
- no automated test suite was available to run in this environment