### PR TITLE
[codex] track scheduled runs in catalog job console

### DIFF
--- a/force-app/main/default/classes/CatalogJobRunner.cls
+++ b/force-app/main/default/classes/CatalogJobRunner.cls
@@ -1,9 +1,7 @@
 public with sharing class CatalogJobRunner {
   private static final String PRODUCT_BATCH_CLASS = 'ProductCatalogExportBatch';
-  private static final String AVAILABILITY_BATCH_CLASS =
-    'BuyerGroupAvailabilityExportBatch';
-  private static final String ACCESS_BATCH_CLASS =
-    'EmbeddedBuyerGroupAccessExportBatch';
+  private static final String AVAILABILITY_BATCH_CLASS = 'BuyerGroupAvailabilityExportBatch';
+  private static final String ACCESS_BATCH_CLASS = 'EmbeddedBuyerGroupAccessExportBatch';
 
   public class JobLaunchHandle {
     @AuraEnabled
@@ -121,18 +119,21 @@ public with sharing class CatalogJobRunner {
   @AuraEnabled(cacheable=true)
   public static List<Map<String, Object>> getConsoleConfigs() {
     List<CatalogJobConfig__mdt> configs = listConfigs();
-    Map<String, CatalogSyncStateService.Snapshot> snapshotsByDeveloperName =
-      CatalogSyncStateService.getSnapshotsByDeveloperName(configs);
-    Map<String, CatalogProductSyncScheduler.ScheduleSnapshot> scheduleSnapshotsByDeveloperName =
-      CatalogProductSyncScheduler.getScheduleSnapshotsByDeveloperName(configs);
+    Map<String, CatalogSyncStateService.Snapshot> snapshotsByDeveloperName = CatalogSyncStateService.getSnapshotsByDeveloperName(
+      configs
+    );
+    Map<String, CatalogProductSyncScheduler.ScheduleSnapshot> scheduleSnapshotsByDeveloperName = CatalogProductSyncScheduler.getScheduleSnapshotsByDeveloperName(
+      configs
+    );
     List<Map<String, Object>> consoleConfigs = new List<Map<String, Object>>();
 
     for (CatalogJobConfig__mdt config : configs) {
       CatalogSyncStateService.Snapshot snapshot = snapshotsByDeveloperName.get(
         config.DeveloperName
       );
-      CatalogProductSyncScheduler.ScheduleSnapshot scheduleSnapshot =
-        scheduleSnapshotsByDeveloperName.get(config.DeveloperName);
+      CatalogProductSyncScheduler.ScheduleSnapshot scheduleSnapshot = scheduleSnapshotsByDeveloperName.get(
+        config.DeveloperName
+      );
       consoleConfigs.add(
         new Map<String, Object>{
           'DeveloperName' => config.DeveloperName,
@@ -148,13 +149,10 @@ public with sharing class CatalogJobRunner {
           'BuilderType__c' => config.BuilderType__c,
           'CatalogId__c' => config.CatalogId__c,
           'BatchSize__c' => config.BatchSize__c,
-          'EnableBuyerGroupAvailability__c' =>
-            config.EnableBuyerGroupAvailability__c,
-          'BuyerGroupAvailabilityMode__c' =>
-            config.BuyerGroupAvailabilityMode__c,
+          'EnableBuyerGroupAvailability__c' => config.EnableBuyerGroupAvailability__c,
+          'BuyerGroupAvailabilityMode__c' => config.BuyerGroupAvailabilityMode__c,
           'SyncMode__c' => CatalogSyncMode.resolve(config),
-          'BaselineFullConfigDeveloperName__c' =>
-            config.BaselineFullConfigDeveloperName__c,
+          'BaselineFullConfigDeveloperName__c' => config.BaselineFullConfigDeveloperName__c,
           'deltaReady' => snapshot == null ? true : snapshot.deltaReady,
           'deltaReadinessMessage' => snapshot == null
             ? null
@@ -187,6 +185,9 @@ public with sharing class CatalogJobRunner {
           'currentProductIsActive' => snapshot == null
             ? false
             : snapshot.currentProductIsActive,
+          'recentProductRuns' => snapshot == null
+            ? new List<Object>()
+            : snapshot.recentProductRuns,
           'isScheduled' => scheduleSnapshot == null
             ? false
             : scheduleSnapshot.isScheduled,
@@ -239,7 +240,9 @@ public with sharing class CatalogJobRunner {
   }
 
   @AuraEnabled
-  public static LaunchResult runSingleAvailability(String jobConfigDeveloperName) {
+  public static LaunchResult runSingleAvailability(
+    String jobConfigDeveloperName
+  ) {
     CatalogJobConfig__mdt config = getConfig(jobConfigDeveloperName);
     validateBuyerGroupAccessEnabled(config);
     return launchForConfig(config, false, true, 'availability');
@@ -300,8 +303,7 @@ public with sharing class CatalogJobRunner {
   @AuraEnabled
   public static String abortCurrentProductRun(String jobConfigDeveloperName) {
     CatalogJobConfig__mdt config = getConfig(jobConfigDeveloperName);
-    CatalogSyncStateService.Snapshot snapshot =
-      CatalogSyncStateService.getSnapshotsByDeveloperName(
+    CatalogSyncStateService.Snapshot snapshot = CatalogSyncStateService.getSnapshotsByDeveloperName(
         new List<CatalogJobConfig__mdt>{ config }
       )
       .get(config.DeveloperName);
@@ -398,7 +400,9 @@ public with sharing class CatalogJobRunner {
 
       RunSnapshot snapshot = new RunSnapshot();
       snapshot.jobId = String.valueOf(job.Id);
-      snapshot.apexClassName = job.ApexClass != null ? job.ApexClass.Name : null;
+      snapshot.apexClassName = job.ApexClass != null
+        ? job.ApexClass.Name
+        : null;
       snapshot.channel = inferChannel(snapshot.apexClassName);
       snapshot.status = job.Status;
       snapshot.jobItemsProcessed = job.JobItemsProcessed;
@@ -471,11 +475,14 @@ public with sharing class CatalogJobRunner {
     launch.label = config.Label;
     launch.mode = mode;
     launch.productSyncMode = CatalogSyncMode.resolve(config);
-    launch.availabilityEnabled =
-      CatalogBuyerGroupAvailabilityMode.isBuyerGroupAccessEnabled(config);
-    launch.buyerGroupAvailabilityMode =
-      CatalogBuyerGroupAvailabilityMode.resolve(config);
-    launch.launchedAt = DateTime.now().formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
+    launch.availabilityEnabled = CatalogBuyerGroupAvailabilityMode.isBuyerGroupAccessEnabled(
+      config
+    );
+    launch.buyerGroupAvailabilityMode = CatalogBuyerGroupAvailabilityMode.resolve(
+      config
+    );
+    launch.launchedAt = DateTime.now()
+      .formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
     launch.jobs = new List<JobLaunchHandle>();
     return launch;
   }
@@ -497,25 +504,29 @@ public with sharing class CatalogJobRunner {
     }
   }
 
-  private static JobLaunchHandle launchProductJob(CatalogJobConfig__mdt config) {
+  private static JobLaunchHandle launchProductJob(
+    CatalogJobConfig__mdt config
+  ) {
     if (CatalogSyncMode.isDelta(config)) {
-      CatalogSyncStateService.DeltaReadiness readiness =
-        CatalogSyncStateService.requireDeltaReadiness(config);
+      CatalogSyncStateService.DeltaReadiness readiness = CatalogSyncStateService.requireDeltaReadiness(
+        config
+      );
       Datetime baselineTimestamp = readiness.stateRecord.LastSuccessfulSyncAt__c;
       Datetime runCutoff = System.now();
-      CatalogDeltaScopeResolver.ScopeMetrics metrics =
-        CatalogDeltaScopeResolver.describeScope(
-          config,
-          baselineTimestamp,
-          runCutoff
-        );
-      DeltaProductCatalogExportBatch deltaBatch =
-        new DeltaProductCatalogExportBatch(
-          config.DeveloperName,
-          baselineTimestamp,
-          runCutoff
-        );
-      Id deltaJobId = Database.executeBatch(deltaBatch, deltaBatch.getBatchSize());
+      CatalogDeltaScopeResolver.ScopeMetrics metrics = CatalogDeltaScopeResolver.describeScope(
+        config,
+        baselineTimestamp,
+        runCutoff
+      );
+      DeltaProductCatalogExportBatch deltaBatch = new DeltaProductCatalogExportBatch(
+        config.DeveloperName,
+        baselineTimestamp,
+        runCutoff
+      );
+      Id deltaJobId = Database.executeBatch(
+        deltaBatch,
+        deltaBatch.getBatchSize()
+      );
       CatalogSyncStateService.recordStartedProductSync(
         config,
         CatalogSyncMode.DELTA,
@@ -552,8 +563,9 @@ public with sharing class CatalogJobRunner {
   }
 
   private static JobLaunchHandle launchEmbeddedAccessJob(String developerName) {
-    EmbeddedBuyerGroupAccessExportBatch batch =
-      new EmbeddedBuyerGroupAccessExportBatch(developerName);
+    EmbeddedBuyerGroupAccessExportBatch batch = new EmbeddedBuyerGroupAccessExportBatch(
+      developerName
+    );
     Id jobId = Database.executeBatch(batch, batch.getBatchSize());
     return createLaunchHandle(jobId, 'access', 'Embedded Access Sync');
   }
@@ -597,21 +609,20 @@ public with sharing class CatalogJobRunner {
       handle.impactedProductCount = metrics.impactedProductCount;
       handle.changedRootProductCount = metrics.rootProductCount;
       handle.exportProductCount = metrics.exportProductCount;
-      handle.scopeSummary =
-        metrics.exportProductCount > 0
-          ? metrics.impactedProductCount +
-            ' impacted product' +
-            (metrics.impactedProductCount == 1 ? '' : 's') +
-            ' since last sync • ' +
-            metrics.rootProductCount +
-            ' changed root' +
-            (metrics.rootProductCount == 1 ? '' : 's') +
-            ' • ' +
-            metrics.exportProductCount +
-            ' product' +
-            (metrics.exportProductCount == 1 ? '' : 's') +
-            ' queued for export'
-          : metrics.impactedProductCount > 0
+      handle.scopeSummary = metrics.exportProductCount > 0
+        ? metrics.impactedProductCount +
+          ' impacted product' +
+          (metrics.impactedProductCount == 1 ? '' : 's') +
+          ' since last sync • ' +
+          metrics.rootProductCount +
+          ' changed root' +
+          (metrics.rootProductCount == 1 ? '' : 's') +
+          ' • ' +
+          metrics.exportProductCount +
+          ' product' +
+          (metrics.exportProductCount == 1 ? '' : 's') +
+          ' queued for export'
+        : metrics.impactedProductCount > 0
             ? metrics.impactedProductCount +
               ' impacted product' +
               (metrics.impactedProductCount == 1 ? '' : 's') +
@@ -621,7 +632,9 @@ public with sharing class CatalogJobRunner {
     return handle;
   }
 
-  private static CatalogJobConfig__mdt getConfig(String jobConfigDeveloperName) {
+  private static CatalogJobConfig__mdt getConfig(
+    String jobConfigDeveloperName
+  ) {
     List<CatalogJobConfig__mdt> configs = [
       SELECT
         DeveloperName,
@@ -688,9 +701,7 @@ public with sharing class CatalogJobRunner {
   ) {
     if (!CatalogBuyerGroupAvailabilityMode.isBuyerGroupAccessEnabled(config)) {
       throw new CatalogJobConfigException(
-        'Buyer Group access is disabled for ' +
-        config.Label +
-        '.'
+        'Buyer Group access is disabled for ' + config.Label + '.'
       );
     }
   }
@@ -729,8 +740,6 @@ public with sharing class CatalogJobRunner {
 
   @TestVisible
   private static Boolean isTerminalStatus(String status) {
-    return status == 'Completed' ||
-      status == 'Failed' ||
-      status == 'Aborted';
+    return status == 'Completed' || status == 'Failed' || status == 'Aborted';
   }
 }

--- a/force-app/main/default/classes/CatalogJobRunnerTest.cls
+++ b/force-app/main/default/classes/CatalogJobRunnerTest.cls
@@ -1,7 +1,8 @@
 @IsTest
 private class CatalogJobRunnerTest {
   private class NoOpQueueable implements Queueable {
-    public void execute(QueueableContext context) {}
+    public void execute(QueueableContext context) {
+    }
   }
 
   private static CatalogJobConfig__mdt findConfigByResolvedMode(String mode) {
@@ -23,8 +24,8 @@ private class CatalogJobRunnerTest {
 
     return Database.countQuery(
         'SELECT COUNT() FROM WebStoreBuyerGroup WHERE WebStoreId = \'' +
-        String.escapeSingleQuotes(webStoreId) +
-        '\' AND BuyerGroupId != NULL'
+          String.escapeSingleQuotes(webStoreId) +
+          '\' AND BuyerGroupId != NULL'
       ) > 0;
   }
 
@@ -132,9 +133,11 @@ private class CatalogJobRunnerTest {
       System.assert(
         exceptionMessage.contains('List has no rows') ||
           exceptionMessage.contains('No CatalogJobConfig__mdt record found') ||
-          exceptionMessage.contains('Run the baseline full sync once before running delta sync'),
+          exceptionMessage.contains(
+            'Run the baseline full sync once before running delta sync'
+          ),
         'Known-config launches can fail in tests when org prerequisites are unavailable. ' +
-          exceptionMessage
+        exceptionMessage
       );
     }
   }
@@ -202,9 +205,9 @@ private class CatalogJobRunnerTest {
     } else {
       System.assert(
         exceptionMessage.contains('List has no rows') ||
-          exceptionMessage.contains('No CatalogJobConfig__mdt record found'),
+        exceptionMessage.contains('No CatalogJobConfig__mdt record found'),
         'Embedded runSingleAvailability should only fail for missing packaged prerequisites. ' +
-          exceptionMessage
+        exceptionMessage
       );
     }
   }
@@ -289,10 +292,12 @@ private class CatalogJobRunnerTest {
       } else {
         System.assert(
           exceptionMessage.contains('List has no rows') ||
-            exceptionMessage.contains('No CatalogJobConfig__mdt record found') ||
+            exceptionMessage.contains(
+              'No CatalogJobConfig__mdt record found'
+            ) ||
             exceptionMessage.contains('No BuyerGroup records found'),
           'Known combined launches should only fail for missing packaged prerequisites. ' +
-            exceptionMessage
+          exceptionMessage
         );
       }
     }
@@ -371,7 +376,7 @@ private class CatalogJobRunnerTest {
         exceptionMessage.contains('No CatalogJobConfig__mdt record found') ||
         exceptionMessage.contains('No BuyerGroup records found'),
       'runAllActiveBoth should only fail for missing packaged prerequisites. ' +
-        exceptionMessage
+      exceptionMessage
     );
   }
 
@@ -484,8 +489,7 @@ private class CatalogJobRunnerTest {
       String additionalFields = config.AdditionalProductFields__c;
       Decimal batchSize = config.BatchSize__c;
       String syncMode = config.SyncMode__c;
-      String baselineFullConfigDeveloperName =
-        config.BaselineFullConfigDeveloperName__c;
+      String baselineFullConfigDeveloperName = config.BaselineFullConfigDeveloperName__c;
       String builderType = config.BuilderType__c;
       String catalogId = config.CatalogId__c;
 
@@ -546,20 +550,18 @@ private class CatalogJobRunnerTest {
     CatalogJobRunner.LaunchResult launch = new CatalogJobRunner.LaunchResult();
     launch.jobs = new List<CatalogJobRunner.JobLaunchHandle>();
 
-    CatalogJobRunner.JobLaunchHandle productHandle =
+    CatalogJobRunner.JobLaunchHandle productHandle = CatalogJobRunner.createLaunchHandle(
+      Test.getStandardPricebookId(),
+      'products',
+      'Product Sync'
+    );
+    List<CatalogJobRunner.JobLaunchHandle> accessHandles = new List<CatalogJobRunner.JobLaunchHandle>{
       CatalogJobRunner.createLaunchHandle(
-        Test.getStandardPricebookId(),
-        'products',
-        'Product Sync'
-      );
-    List<CatalogJobRunner.JobLaunchHandle> accessHandles =
-      new List<CatalogJobRunner.JobLaunchHandle>{
-        CatalogJobRunner.createLaunchHandle(
-          UserInfo.getUserId(),
-          'access',
-          'Embedded Access Sync'
-        )
-      };
+        UserInfo.getUserId(),
+        'access',
+        'Embedded Access Sync'
+      )
+    };
 
     CatalogJobRunner.appendLaunchHandles(
       launch,
@@ -606,8 +608,7 @@ private class CatalogJobRunnerTest {
 
   @IsTest
   static void testCreateLaunchHandle_assignsDeltaScopeSummary() {
-    CatalogDeltaScopeResolver.ScopeMetrics metrics =
-      new CatalogDeltaScopeResolver.ScopeMetrics();
+    CatalogDeltaScopeResolver.ScopeMetrics metrics = new CatalogDeltaScopeResolver.ScopeMetrics();
     metrics.impactedProductCount = 3;
     metrics.rootProductCount = 2;
     metrics.exportProductCount = 5;
@@ -650,7 +651,8 @@ private class CatalogJobRunnerTest {
     } catch (CatalogJobConfigException e) {
       exceptionThrown = true;
       System.assert(
-        e.getMessage().contains('Buyer Group access is disabled for Disabled Config.'),
+        e.getMessage()
+          .contains('Buyer Group access is disabled for Disabled Config.'),
         'The error should mention the disabled config label'
       );
     }
@@ -670,7 +672,10 @@ private class CatalogJobRunnerTest {
       SyncMode__c = CatalogSyncMode.DELTA
     );
 
-    System.assertEquals(false, CatalogJobRunner.isProductSyncReady(deltaConfig));
+    System.assertEquals(
+      false,
+      CatalogJobRunner.isProductSyncReady(deltaConfig)
+    );
   }
 
   @IsTest
@@ -690,6 +695,7 @@ private class CatalogJobRunnerTest {
       System.assert(config.containsKey('currentProductConfigDeveloperName'));
       System.assert(config.containsKey('currentProductStartedAt'));
       System.assert(config.containsKey('currentProductIsActive'));
+      System.assert(config.containsKey('recentProductRuns'));
       System.assert(config.containsKey('isScheduled'));
       System.assert(config.containsKey('scheduleState'));
       System.assert(config.containsKey('resolvedTargetKey'));
@@ -720,8 +726,9 @@ private class CatalogJobRunnerTest {
     CatalogSyncStateService.testAsyncJobStatusesById = new Map<String, String>{
       String.valueOf(jobId) => 'Processing'
     };
-    CatalogSyncStateService.testAsyncJobCreatedDatesById =
-      new Map<String, Datetime>{ String.valueOf(jobId) => System.now() };
+    CatalogSyncStateService.testAsyncJobCreatedDatesById = new Map<String, Datetime>{
+      String.valueOf(jobId) => System.now()
+    };
     String abortedJobId = CatalogJobRunner.abortCurrentProductRun(
       config.DeveloperName
     );
@@ -793,8 +800,7 @@ private class CatalogJobRunnerTest {
     launch.label = 'Label';
     launch.mode = 'products';
     launch.availabilityEnabled = true;
-    launch.buyerGroupAvailabilityMode =
-      CatalogBuyerGroupAvailabilityMode.PAIRED_SOURCE;
+    launch.buyerGroupAvailabilityMode = CatalogBuyerGroupAvailabilityMode.PAIRED_SOURCE;
     launch.launchedAt = '2026-04-01T00:00:00Z';
     launch.jobs = new List<CatalogJobRunner.JobLaunchHandle>{ handle };
 

--- a/force-app/main/default/classes/CatalogSyncStateService.cls
+++ b/force-app/main/default/classes/CatalogSyncStateService.cls
@@ -1,4 +1,6 @@
 public with sharing class CatalogSyncStateService {
+  private static final Integer MAX_RECENT_PRODUCT_RUNS = 8;
+
   @TestVisible
   private static Map<String, CatalogJobConfig__mdt> testConfigsByDeveloperName;
   @TestVisible
@@ -24,8 +26,26 @@ public with sharing class CatalogSyncStateService {
     public String currentProductConfigDeveloperName { get; set; }
     public String currentProductStartedAt { get; set; }
     public Boolean currentProductIsActive { get; set; }
+    public List<RecentProductRun> recentProductRuns { get; set; }
     public Boolean deltaReady { get; set; }
     public String deltaReadinessMessage { get; set; }
+  }
+
+  public class RecentProductRun {
+    @AuraEnabled
+    public String jobId { get; set; }
+    @AuraEnabled
+    public String runMode { get; set; }
+    @AuraEnabled
+    public String configDeveloperName { get; set; }
+    @AuraEnabled
+    public String status { get; set; }
+    @AuraEnabled
+    public String startedAt { get; set; }
+    @AuraEnabled
+    public String completedAt { get; set; }
+    @AuraEnabled
+    public Boolean isTerminal { get; set; }
   }
 
   public class DeltaReadiness {
@@ -44,6 +64,15 @@ public with sharing class CatalogSyncStateService {
     public Boolean isTerminal { get; set; }
   }
 
+  private class StoredRecentProductRun {
+    public String jobId { get; set; }
+    public String runMode { get; set; }
+    public String configDeveloperName { get; set; }
+    public String status { get; set; }
+    public String startedAt { get; set; }
+    public String completedAt { get; set; }
+  }
+
   public static String buildResolvedTargetKey(CatalogJobConfig__mdt jobConfig) {
     List<String> resolvedTarget = new List<String>{
       'orgId',
@@ -57,9 +86,7 @@ public with sharing class CatalogSyncStateService {
       'catalogId',
       normalizeText(jobConfig == null ? null : jobConfig.CatalogId__c),
       'productFilter',
-      normalizeText(
-        jobConfig == null ? null : jobConfig.ProductFilter__c
-      ),
+      normalizeText(jobConfig == null ? null : jobConfig.ProductFilter__c),
       'additionalProductFields',
       canonicalizeCsv(
         jobConfig == null ? null : jobConfig.AdditionalProductFields__c
@@ -67,18 +94,19 @@ public with sharing class CatalogSyncStateService {
       'locale',
       normalizeText(jobConfig == null ? null : jobConfig.Locale__c),
       'buyerGroupAvailabilityMode',
-      CatalogBuyerGroupAvailabilityMode.resolve(
-        jobConfig
-      ),
+      CatalogBuyerGroupAvailabilityMode.resolve(jobConfig),
       'embeddedWebStoreId',
       (jobConfig != null &&
-          CatalogBuyerGroupAvailabilityMode.usesEmbedded(jobConfig))
+        CatalogBuyerGroupAvailabilityMode.usesEmbedded(jobConfig))
         ? normalizeText(jobConfig.WebStoreId__c)
         : ''
     };
 
     return EncodingUtil.convertToHex(
-      Crypto.generateDigest('SHA-256', Blob.valueOf(JSON.serialize(resolvedTarget)))
+      Crypto.generateDigest(
+        'SHA-256',
+        Blob.valueOf(JSON.serialize(resolvedTarget))
+      )
     );
   }
 
@@ -108,17 +136,22 @@ public with sharing class CatalogSyncStateService {
         CatalogSyncMode.isDelta(config) &&
         String.isNotBlank(config.BaselineFullConfigDeveloperName__c)
       ) {
-        deltaBaselineNames.add(config.BaselineFullConfigDeveloperName__c.trim());
+        deltaBaselineNames.add(
+          config.BaselineFullConfigDeveloperName__c.trim()
+        );
       }
     }
 
-    Map<String, CatalogJobConfig__mdt> baselineConfigsByDeveloperName =
-      loadConfigsByDeveloperName(deltaBaselineNames);
+    Map<String, CatalogJobConfig__mdt> baselineConfigsByDeveloperName = loadConfigsByDeveloperName(
+      deltaBaselineNames
+    );
     Set<String> stateKeys = new Set<String>();
     stateKeys.addAll(targetKeyByDeveloperName.values());
 
     Map<String, String> baselineKeyByDeveloperName = new Map<String, String>();
-    for (CatalogJobConfig__mdt baselineConfig : baselineConfigsByDeveloperName.values()) {
+    for (
+      CatalogJobConfig__mdt baselineConfig : baselineConfigsByDeveloperName.values()
+    ) {
       String baselineTargetKey = buildResolvedTargetKey(baselineConfig);
       baselineKeyByDeveloperName.put(
         baselineConfig.DeveloperName,
@@ -134,6 +167,16 @@ public with sharing class CatalogSyncStateService {
     for (Catalog_Sync_State__c stateRecord : statesByTargetKey.values()) {
       if (String.isNotBlank(stateRecord.CurrentProductJobId__c)) {
         trackedProductJobIds.add(stateRecord.CurrentProductJobId__c);
+      }
+
+      for (
+        StoredRecentProductRun storedRun : extractStoredRecentProductRuns(
+          stateRecord
+        )
+      ) {
+        if (String.isNotBlank(storedRun.jobId)) {
+          trackedProductJobIds.add(storedRun.jobId);
+        }
       }
     }
     Map<String, TrackedAsyncJob> trackedJobsById = loadTrackedJobsById(
@@ -164,7 +207,8 @@ public with sharing class CatalogSyncStateService {
         stateRecord,
         trackedJobsById.get(
           stateRecord == null ? null : stateRecord.CurrentProductJobId__c
-        )
+        ),
+        trackedJobsById
       );
       snapshotsByDeveloperName.put(config.DeveloperName, snapshot);
     }
@@ -172,7 +216,9 @@ public with sharing class CatalogSyncStateService {
     return snapshotsByDeveloperName;
   }
 
-  public static DeltaReadiness requireDeltaReadiness(CatalogJobConfig__mdt config) {
+  public static DeltaReadiness requireDeltaReadiness(
+    CatalogJobConfig__mdt config
+  ) {
     DeltaReadiness readiness = evaluateDeltaReadiness(config);
     if (readiness.isReady != true) {
       throw new CatalogJobConfigException(readiness.message);
@@ -180,7 +226,9 @@ public with sharing class CatalogSyncStateService {
     return readiness;
   }
 
-  public static DeltaReadiness evaluateDeltaReadiness(CatalogJobConfig__mdt config) {
+  public static DeltaReadiness evaluateDeltaReadiness(
+    CatalogJobConfig__mdt config
+  ) {
     DeltaReadiness readiness = new DeltaReadiness();
     readiness.resolvedTargetKey = buildResolvedTargetKey(config);
     readiness.isReady = false;
@@ -193,8 +241,7 @@ public with sharing class CatalogSyncStateService {
     }
 
     if (String.isBlank(config.BaselineFullConfigDeveloperName__c)) {
-      readiness.message =
-        'BaselineFullConfigDeveloperName__c is required for Delta sync mode.';
+      readiness.message = 'BaselineFullConfigDeveloperName__c is required for Delta sync mode.';
       return readiness;
     }
 
@@ -224,11 +271,17 @@ public with sharing class CatalogSyncStateService {
     String baselineTargetKey = buildResolvedTargetKey(readiness.baselineConfig);
     readiness.stateRecord = loadStateByTargetKey(readiness.resolvedTargetKey);
     TrackedAsyncJob trackedJob = loadTrackedJobsById(
-      new Set<String>{
-        readiness.stateRecord == null ? null : readiness.stateRecord.CurrentProductJobId__c
-      }
-    )
-    .get(readiness.stateRecord == null ? null : readiness.stateRecord.CurrentProductJobId__c);
+        new Set<String>{
+          readiness.stateRecord == null
+            ? null
+            : readiness.stateRecord.CurrentProductJobId__c
+        }
+      )
+      .get(
+        readiness.stateRecord == null
+          ? null
+          : readiness.stateRecord.CurrentProductJobId__c
+      );
     String readinessFailure = evaluateDeltaReadinessFailure(
       config,
       readiness.baselineConfig,
@@ -263,6 +316,12 @@ public with sharing class CatalogSyncStateService {
     stateRecord.LastSuccessfulSyncAt__c = cutoff;
     stateRecord.LastRunMode__c = CatalogSyncMode.FULL;
     stateRecord.LastSuccessfulConfigDeveloperName__c = config.DeveloperName;
+    markCurrentRecentProductRunCompleted(
+      stateRecord,
+      CatalogSyncMode.FULL,
+      config.DeveloperName,
+      cutoff
+    );
     upsert stateRecord ResolvedTargetKey__c;
   }
 
@@ -278,12 +337,17 @@ public with sharing class CatalogSyncStateService {
     }
 
     if (String.isNotBlank(config.BaselineFullConfigDeveloperName__c)) {
-      stateRecord.BaselineFullConfigDeveloperName__c =
-        config.BaselineFullConfigDeveloperName__c.trim();
+      stateRecord.BaselineFullConfigDeveloperName__c = config.BaselineFullConfigDeveloperName__c.trim();
     }
     stateRecord.LastSuccessfulSyncAt__c = cutoff;
     stateRecord.LastRunMode__c = CatalogSyncMode.DELTA;
     stateRecord.LastSuccessfulConfigDeveloperName__c = config.DeveloperName;
+    markCurrentRecentProductRunCompleted(
+      stateRecord,
+      CatalogSyncMode.DELTA,
+      config.DeveloperName,
+      cutoff
+    );
     upsert stateRecord ResolvedTargetKey__c;
   }
 
@@ -307,8 +371,7 @@ public with sharing class CatalogSyncStateService {
     if (CatalogSyncMode.isFull(config)) {
       stateRecord.BaselineFullConfigDeveloperName__c = config.DeveloperName;
     } else if (String.isNotBlank(config.BaselineFullConfigDeveloperName__c)) {
-      stateRecord.BaselineFullConfigDeveloperName__c =
-        config.BaselineFullConfigDeveloperName__c.trim();
+      stateRecord.BaselineFullConfigDeveloperName__c = config.BaselineFullConfigDeveloperName__c.trim();
     }
 
     stateRecord.CurrentProductJobId__c = String.valueOf(jobId);
@@ -317,6 +380,13 @@ public with sharing class CatalogSyncStateService {
     stateRecord.CurrentProductStartedAt__c = startedAt == null
       ? System.now()
       : startedAt;
+    recordRecentProductRunStart(
+      stateRecord,
+      String.valueOf(jobId),
+      runMode,
+      config.DeveloperName,
+      startedAt
+    );
 
     upsert stateRecord ResolvedTargetKey__c;
   }
@@ -336,7 +406,8 @@ public with sharing class CatalogSyncStateService {
     String targetKey,
     String baselineTargetKey,
     Catalog_Sync_State__c stateRecord,
-    TrackedAsyncJob trackedJob
+    TrackedAsyncJob trackedJob,
+    Map<String, TrackedAsyncJob> trackedJobsById
   ) {
     Snapshot snapshot = new Snapshot();
     snapshot.resolvedTargetKey = targetKey;
@@ -352,7 +423,9 @@ public with sharing class CatalogSyncStateService {
     snapshot.lastSuccessfulSyncAt = formatDatetime(
       stateRecord == null ? null : stateRecord.LastSuccessfulSyncAt__c
     );
-    snapshot.lastRunMode = stateRecord == null ? null : stateRecord.LastRunMode__c;
+    snapshot.lastRunMode = stateRecord == null
+      ? null
+      : stateRecord.LastRunMode__c;
     snapshot.lastSuccessfulConfigDeveloperName = stateRecord == null
       ? null
       : stateRecord.LastSuccessfulConfigDeveloperName__c;
@@ -360,8 +433,7 @@ public with sharing class CatalogSyncStateService {
       snapshot.currentProductJobId = trackedJob.jobId;
       snapshot.currentProductJobStatus = trackedJob.status;
       snapshot.currentProductRunMode = stateRecord.CurrentProductRunMode__c;
-      snapshot.currentProductConfigDeveloperName =
-        stateRecord.CurrentProductConfigDeveloperName__c;
+      snapshot.currentProductConfigDeveloperName = stateRecord.CurrentProductConfigDeveloperName__c;
       snapshot.currentProductStartedAt = formatDatetime(
         trackedJob.createdDate == null
           ? stateRecord.CurrentProductStartedAt__c
@@ -371,6 +443,10 @@ public with sharing class CatalogSyncStateService {
     } else {
       snapshot.currentProductIsActive = false;
     }
+    snapshot.recentProductRuns = buildRecentProductRuns(
+      stateRecord,
+      trackedJobsById
+    );
 
     if (!CatalogSyncMode.isDelta(config)) {
       snapshot.deltaReady = true;
@@ -406,31 +482,30 @@ public with sharing class CatalogSyncStateService {
     }
 
     if (baselineConfig == null) {
-      return
-        'Baseline full config "' +
+      return 'Baseline full config "' +
         config.BaselineFullConfigDeveloperName__c.trim() +
         '" was not found.';
     }
 
     if (!CatalogSyncMode.isFull(baselineConfig)) {
-      return
-        'Baseline full config "' +
+      return 'Baseline full config "' +
         baselineConfig.DeveloperName +
         '" must use SyncMode__c = Full.';
     }
 
     if (baselineTargetKey != targetKey) {
-      return
-        'Baseline full config "' +
+      return 'Baseline full config "' +
         baselineConfig.DeveloperName +
         '" does not resolve to the same export target as delta config "' +
         config.DeveloperName +
         '".';
     }
 
-    if (stateRecord == null || stateRecord.LastSuccessfulFullSyncAt__c == null) {
-      return
-        'Run the baseline full sync once before running delta sync "' +
+    if (
+      stateRecord == null ||
+      stateRecord.LastSuccessfulFullSyncAt__c == null
+    ) {
+      return 'Run the baseline full sync once before running delta sync "' +
         config.DeveloperName +
         '".';
     }
@@ -445,8 +520,7 @@ public with sharing class CatalogSyncStateService {
         )
         ? baselineConfig.DeveloperName
         : stateRecord.CurrentProductConfigDeveloperName__c;
-      return
-        'Baseline full sync "' +
+      return 'Baseline full sync "' +
         activeFullConfigDeveloperName +
         '" is currently running. Wait for it to complete before running delta sync "' +
         config.DeveloperName +
@@ -459,8 +533,7 @@ public with sharing class CatalogSyncStateService {
   private static Map<String, CatalogJobConfig__mdt> loadConfigsByDeveloperName(
     Set<String> developerNames
   ) {
-    Map<String, CatalogJobConfig__mdt> configsByDeveloperName =
-      new Map<String, CatalogJobConfig__mdt>();
+    Map<String, CatalogJobConfig__mdt> configsByDeveloperName = new Map<String, CatalogJobConfig__mdt>();
 
     if (developerNames == null || developerNames.isEmpty()) {
       return configsByDeveloperName;
@@ -509,8 +582,7 @@ public with sharing class CatalogSyncStateService {
   private static Map<String, Catalog_Sync_State__c> loadStatesByTargetKey(
     Set<String> targetKeys
   ) {
-    Map<String, Catalog_Sync_State__c> statesByTargetKey =
-      new Map<String, Catalog_Sync_State__c>();
+    Map<String, Catalog_Sync_State__c> statesByTargetKey = new Map<String, Catalog_Sync_State__c>();
 
     if (targetKeys == null || targetKeys.isEmpty()) {
       return statesByTargetKey;
@@ -518,7 +590,9 @@ public with sharing class CatalogSyncStateService {
 
     if (Test.isRunningTest() && testStatesByTargetKey != null) {
       for (String targetKey : targetKeys) {
-        Catalog_Sync_State__c stateRecord = testStatesByTargetKey.get(targetKey);
+        Catalog_Sync_State__c stateRecord = testStatesByTargetKey.get(
+          targetKey
+        );
         if (stateRecord != null) {
           statesByTargetKey.put(targetKey, stateRecord);
         }
@@ -538,7 +612,8 @@ public with sharing class CatalogSyncStateService {
         LastSuccessfulFullSyncAt__c,
         LastSuccessfulSyncAt__c,
         LastRunMode__c,
-        LastSuccessfulConfigDeveloperName__c
+        LastSuccessfulConfigDeveloperName__c,
+        RecentProductRunsJson__c
       FROM Catalog_Sync_State__c
       WHERE ResolvedTargetKey__c IN :targetKeys
     ]) {
@@ -569,7 +644,8 @@ public with sharing class CatalogSyncStateService {
         LastSuccessfulFullSyncAt__c,
         LastSuccessfulSyncAt__c,
         LastRunMode__c,
-        LastSuccessfulConfigDeveloperName__c
+        LastSuccessfulConfigDeveloperName__c,
+        RecentProductRunsJson__c
       FROM Catalog_Sync_State__c
       WHERE ResolvedTargetKey__c = :targetKey
       LIMIT 1
@@ -647,6 +723,324 @@ public with sharing class CatalogSyncStateService {
     return status == 'Completed' || status == 'Aborted' || status == 'Failed';
   }
 
+  private static void recordRecentProductRunStart(
+    Catalog_Sync_State__c stateRecord,
+    String jobId,
+    String runMode,
+    String configDeveloperName,
+    Datetime startedAt
+  ) {
+    if (stateRecord == null || String.isBlank(jobId)) {
+      return;
+    }
+
+    StoredRecentProductRun recentRun = new StoredRecentProductRun();
+    recentRun.jobId = jobId;
+    recentRun.runMode = CatalogSyncMode.resolve(runMode);
+    recentRun.configDeveloperName = configDeveloperName;
+    recentRun.status = 'Queued';
+    recentRun.startedAt = formatDatetime(
+      startedAt == null ? System.now() : startedAt
+    );
+    recentRun.completedAt = null;
+    stateRecord.RecentProductRunsJson__c = serializeRecentProductRuns(
+      upsertRecentProductRun(
+        extractStoredRecentProductRuns(stateRecord),
+        recentRun
+      )
+    );
+  }
+
+  private static void markCurrentRecentProductRunCompleted(
+    Catalog_Sync_State__c stateRecord,
+    String runMode,
+    String configDeveloperName,
+    Datetime completedAt
+  ) {
+    if (
+      stateRecord == null || String.isBlank(stateRecord.CurrentProductJobId__c)
+    ) {
+      return;
+    }
+
+    StoredRecentProductRun recentRun = new StoredRecentProductRun();
+    recentRun.jobId = stateRecord.CurrentProductJobId__c;
+    recentRun.runMode = CatalogSyncMode.resolve(runMode);
+    recentRun.configDeveloperName = configDeveloperName;
+    recentRun.status = 'Completed';
+    recentRun.startedAt = formatDatetime(
+      stateRecord.CurrentProductStartedAt__c
+    );
+    recentRun.completedAt = formatDatetime(
+      completedAt == null ? System.now() : completedAt
+    );
+    stateRecord.RecentProductRunsJson__c = serializeRecentProductRuns(
+      upsertRecentProductRun(
+        extractStoredRecentProductRuns(stateRecord),
+        recentRun
+      )
+    );
+  }
+
+  private static List<RecentProductRun> buildRecentProductRuns(
+    Catalog_Sync_State__c stateRecord,
+    Map<String, TrackedAsyncJob> trackedJobsById
+  ) {
+    List<RecentProductRun> recentProductRuns = new List<RecentProductRun>();
+
+    for (
+      StoredRecentProductRun storedRun : extractStoredRecentProductRuns(
+        stateRecord
+      )
+    ) {
+      if (String.isBlank(storedRun.jobId)) {
+        continue;
+      }
+
+      TrackedAsyncJob trackedJob = trackedJobsById == null
+        ? null
+        : trackedJobsById.get(storedRun.jobId);
+      RecentProductRun recentRun = new RecentProductRun();
+      recentRun.jobId = storedRun.jobId;
+      recentRun.runMode = CatalogSyncMode.resolve(storedRun.runMode);
+      recentRun.configDeveloperName = normalizeStoredRecentProductRunValue(
+        storedRun.configDeveloperName
+      );
+      recentRun.status = trackedJob == null
+        ? defaultRecentProductRunStatus(storedRun)
+        : trackedJob.status;
+      recentRun.startedAt = trackedJob != null &&
+        trackedJob.createdDate != null
+        ? formatDatetime(trackedJob.createdDate)
+        : storedRun.startedAt;
+      recentRun.completedAt = trackedJob != null &&
+        trackedJob.completedDate != null
+        ? formatDatetime(trackedJob.completedDate)
+        : storedRun.completedAt;
+      recentRun.isTerminal = trackedJob != null
+        ? trackedJob.isTerminal
+        : isTerminalAsyncJobStatus(recentRun.status);
+      recentProductRuns.add(recentRun);
+    }
+
+    return recentProductRuns;
+  }
+
+  private static String defaultRecentProductRunStatus(
+    StoredRecentProductRun storedRun
+  ) {
+    if (String.isNotBlank(storedRun.status)) {
+      return storedRun.status;
+    }
+
+    return String.isNotBlank(storedRun.completedAt) ? 'Completed' : 'Queued';
+  }
+
+  private static List<StoredRecentProductRun> extractStoredRecentProductRuns(
+    Catalog_Sync_State__c stateRecord
+  ) {
+    List<StoredRecentProductRun> recentRuns = parseRecentProductRuns(
+      stateRecord == null ? null : stateRecord.RecentProductRunsJson__c
+    );
+
+    if (
+      stateRecord == null || String.isBlank(stateRecord.CurrentProductJobId__c)
+    ) {
+      return recentRuns;
+    }
+
+    StoredRecentProductRun currentRun = new StoredRecentProductRun();
+    currentRun.jobId = stateRecord.CurrentProductJobId__c;
+    currentRun.runMode = stateRecord.CurrentProductRunMode__c;
+    currentRun.configDeveloperName = stateRecord.CurrentProductConfigDeveloperName__c;
+    currentRun.startedAt = formatDatetime(
+      stateRecord.CurrentProductStartedAt__c
+    );
+    return upsertRecentProductRun(recentRuns, currentRun);
+  }
+
+  private static List<StoredRecentProductRun> parseRecentProductRuns(
+    String jsonValue
+  ) {
+    List<StoredRecentProductRun> recentRuns = new List<StoredRecentProductRun>();
+
+    if (String.isBlank(jsonValue)) {
+      return recentRuns;
+    }
+
+    try {
+      for (Object rawRun : (List<Object>) JSON.deserializeUntyped(jsonValue)) {
+        Map<String, Object> rawFields;
+        try {
+          rawFields = (Map<String, Object>) rawRun;
+        } catch (Exception e) {
+          continue;
+        }
+
+        StoredRecentProductRun recentRun = new StoredRecentProductRun();
+        recentRun.jobId = normalizeStoredRecentProductRunValue(
+          rawFields.get('jobId')
+        );
+        recentRun.runMode = normalizeStoredRecentProductRunValue(
+          rawFields.get('runMode')
+        );
+        recentRun.configDeveloperName = normalizeStoredRecentProductRunValue(
+          rawFields.get('configDeveloperName')
+        );
+        recentRun.status = normalizeStoredRecentProductRunValue(
+          rawFields.get('status')
+        );
+        recentRun.startedAt = normalizeStoredRecentProductRunValue(
+          rawFields.get('startedAt')
+        );
+        recentRun.completedAt = normalizeStoredRecentProductRunValue(
+          rawFields.get('completedAt')
+        );
+        if (String.isNotBlank(recentRun.jobId)) {
+          recentRuns.add(recentRun);
+        }
+      }
+    } catch (Exception e) {
+      return new List<StoredRecentProductRun>();
+    }
+
+    return upsertRecentProductRun(
+      new List<StoredRecentProductRun>(),
+      null,
+      recentRuns
+    );
+  }
+
+  private static List<StoredRecentProductRun> upsertRecentProductRun(
+    List<StoredRecentProductRun> existingRuns,
+    StoredRecentProductRun newRun
+  ) {
+    return upsertRecentProductRun(
+      existingRuns,
+      newRun,
+      new List<StoredRecentProductRun>()
+    );
+  }
+
+  private static List<StoredRecentProductRun> upsertRecentProductRun(
+    List<StoredRecentProductRun> existingRuns,
+    StoredRecentProductRun newRun,
+    List<StoredRecentProductRun> additionalRuns
+  ) {
+    Map<String, StoredRecentProductRun> existingRunsByJobId = new Map<String, StoredRecentProductRun>();
+    List<String> orderedJobIds = new List<String>();
+
+    for (StoredRecentProductRun existingRun : existingRuns) {
+      if (existingRun == null || String.isBlank(existingRun.jobId)) {
+        continue;
+      }
+
+      existingRunsByJobId.put(existingRun.jobId, existingRun);
+      if (!orderedJobIds.contains(existingRun.jobId)) {
+        orderedJobIds.add(existingRun.jobId);
+      }
+    }
+
+    List<StoredRecentProductRun> mergedRuns = new List<StoredRecentProductRun>();
+    Set<String> includedJobIds = new Set<String>();
+    List<StoredRecentProductRun> preferredRuns = new List<StoredRecentProductRun>();
+
+    if (newRun != null && String.isNotBlank(newRun.jobId)) {
+      preferredRuns.add(newRun);
+    }
+    preferredRuns.addAll(additionalRuns);
+
+    for (StoredRecentProductRun preferredRun : preferredRuns) {
+      if (preferredRun == null || String.isBlank(preferredRun.jobId)) {
+        continue;
+      }
+
+      if (includedJobIds.contains(preferredRun.jobId)) {
+        continue;
+      }
+
+      mergedRuns.add(
+        mergeStoredRecentProductRun(
+          preferredRun,
+          existingRunsByJobId.get(preferredRun.jobId)
+        )
+      );
+      includedJobIds.add(preferredRun.jobId);
+      if (mergedRuns.size() >= MAX_RECENT_PRODUCT_RUNS) {
+        return mergedRuns;
+      }
+    }
+
+    for (String jobId : orderedJobIds) {
+      if (includedJobIds.contains(jobId)) {
+        continue;
+      }
+
+      mergedRuns.add(
+        mergeStoredRecentProductRun(existingRunsByJobId.get(jobId), null)
+      );
+      includedJobIds.add(jobId);
+      if (mergedRuns.size() >= MAX_RECENT_PRODUCT_RUNS) {
+        break;
+      }
+    }
+
+    return mergedRuns;
+  }
+
+  private static StoredRecentProductRun mergeStoredRecentProductRun(
+    StoredRecentProductRun preferredRun,
+    StoredRecentProductRun fallbackRun
+  ) {
+    StoredRecentProductRun mergedRun = new StoredRecentProductRun();
+    mergedRun.jobId = firstNonBlank(
+      preferredRun == null ? null : preferredRun.jobId,
+      fallbackRun == null ? null : fallbackRun.jobId
+    );
+    mergedRun.runMode = CatalogSyncMode.resolve(
+      firstNonBlank(
+        preferredRun == null ? null : preferredRun.runMode,
+        fallbackRun == null ? null : fallbackRun.runMode
+      )
+    );
+    mergedRun.configDeveloperName = firstNonBlank(
+      preferredRun == null ? null : preferredRun.configDeveloperName,
+      fallbackRun == null ? null : fallbackRun.configDeveloperName
+    );
+    mergedRun.status = firstNonBlank(
+      preferredRun == null ? null : preferredRun.status,
+      fallbackRun == null ? null : fallbackRun.status
+    );
+    mergedRun.startedAt = firstNonBlank(
+      preferredRun == null ? null : preferredRun.startedAt,
+      fallbackRun == null ? null : fallbackRun.startedAt
+    );
+    mergedRun.completedAt = firstNonBlank(
+      preferredRun == null ? null : preferredRun.completedAt,
+      fallbackRun == null ? null : fallbackRun.completedAt
+    );
+    return mergedRun;
+  }
+
+  private static String serializeRecentProductRuns(
+    List<StoredRecentProductRun> recentRuns
+  ) {
+    return recentRuns == null || recentRuns.isEmpty()
+      ? null
+      : JSON.serialize(recentRuns);
+  }
+
+  private static String firstNonBlank(
+    String primaryValue,
+    String fallbackValue
+  ) {
+    return String.isNotBlank(primaryValue) ? primaryValue : fallbackValue;
+  }
+
+  private static String normalizeStoredRecentProductRunValue(Object rawValue) {
+    return rawValue == null ? null : String.valueOf(rawValue).trim();
+  }
+
   private static String canonicalizeCsv(String csvValue) {
     List<String> normalizedValues = new List<String>();
 
@@ -656,7 +1050,10 @@ public with sharing class CatalogSyncStateService {
 
     for (String token : csvValue.split(',')) {
       String normalizedToken = normalizeText(token).toLowerCase();
-      if (String.isNotBlank(normalizedToken) && !normalizedValues.contains(normalizedToken)) {
+      if (
+        String.isNotBlank(normalizedToken) &&
+        !normalizedValues.contains(normalizedToken)
+      ) {
         normalizedValues.add(normalizedToken);
       }
     }
@@ -670,6 +1067,8 @@ public with sharing class CatalogSyncStateService {
   }
 
   private static String formatDatetime(Datetime value) {
-    return value == null ? null : value.formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
+    return value == null
+      ? null
+      : value.formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
   }
 }

--- a/force-app/main/default/classes/CatalogSyncStateServiceTest.cls
+++ b/force-app/main/default/classes/CatalogSyncStateServiceTest.cls
@@ -57,12 +57,10 @@ private class CatalogSyncStateServiceTest {
       ResolvedTargetKey__c = CatalogSyncStateService.buildResolvedTargetKey(
         config
       ),
-      BaselineFullConfigDeveloperName__c =
-        config.BaselineFullConfigDeveloperName__c,
+      BaselineFullConfigDeveloperName__c = config.BaselineFullConfigDeveloperName__c,
       CurrentProductJobId__c = currentProductJobId,
       CurrentProductRunMode__c = currentProductRunMode,
-      CurrentProductConfigDeveloperName__c =
-        currentProductConfigDeveloperName,
+      CurrentProductConfigDeveloperName__c = currentProductConfigDeveloperName,
       CurrentProductStartedAt__c = currentProductStartedAt,
       LastSuccessfulFullSyncAt__c = fullCutoff,
       LastSuccessfulSyncAt__c = syncCutoff,
@@ -103,22 +101,33 @@ private class CatalogSyncStateServiceTest {
         LastRunMode__c,
         LastSuccessfulConfigDeveloperName__c
       FROM Catalog_Sync_State__c
-      WHERE ResolvedTargetKey__c = :CatalogSyncStateService.buildResolvedTargetKey(
-        config
-      )
+      WHERE
+        ResolvedTargetKey__c = :CatalogSyncStateService.buildResolvedTargetKey(
+          config
+        )
       LIMIT 1
     ];
 
-    System.assertEquals('FULL_CONFIG', stateRecord.BaselineFullConfigDeveloperName__c);
+    System.assertEquals(
+      'FULL_CONFIG',
+      stateRecord.BaselineFullConfigDeveloperName__c
+    );
     System.assertEquals(cutoff, stateRecord.LastSuccessfulFullSyncAt__c);
     System.assertEquals(cutoff, stateRecord.LastSuccessfulSyncAt__c);
     System.assertEquals(CatalogSyncMode.FULL, stateRecord.LastRunMode__c);
-    System.assertEquals('FULL_CONFIG', stateRecord.LastSuccessfulConfigDeveloperName__c);
+    System.assertEquals(
+      'FULL_CONFIG',
+      stateRecord.LastSuccessfulConfigDeveloperName__c
+    );
   }
 
   @IsTest
   static void testRecordSuccessfulDeltaSync_updatesExistingState() {
-    CatalogJobConfig__mdt fullConfig = createConfig('FULL_CONFIG', 'Full', null);
+    CatalogJobConfig__mdt fullConfig = createConfig(
+      'FULL_CONFIG',
+      'Full',
+      null
+    );
     CatalogJobConfig__mdt deltaConfig = createConfig(
       'DELTA_CONFIG',
       'Delta',
@@ -141,13 +150,17 @@ private class CatalogSyncStateServiceTest {
         LastRunMode__c,
         LastSuccessfulConfigDeveloperName__c
       FROM Catalog_Sync_State__c
-      WHERE ResolvedTargetKey__c = :CatalogSyncStateService.buildResolvedTargetKey(
-        deltaConfig
-      )
+      WHERE
+        ResolvedTargetKey__c = :CatalogSyncStateService.buildResolvedTargetKey(
+          deltaConfig
+        )
       LIMIT 1
     ];
 
-    System.assertEquals('FULL_CONFIG', stateRecord.BaselineFullConfigDeveloperName__c);
+    System.assertEquals(
+      'FULL_CONFIG',
+      stateRecord.BaselineFullConfigDeveloperName__c
+    );
     System.assertEquals(fullCutoff, stateRecord.LastSuccessfulFullSyncAt__c);
     System.assertEquals(deltaCutoff, stateRecord.LastSuccessfulSyncAt__c);
     System.assertEquals(CatalogSyncMode.DELTA, stateRecord.LastRunMode__c);
@@ -176,11 +189,13 @@ private class CatalogSyncStateServiceTest {
         CurrentProductJobId__c,
         CurrentProductRunMode__c,
         CurrentProductConfigDeveloperName__c,
-        CurrentProductStartedAt__c
+        CurrentProductStartedAt__c,
+        RecentProductRunsJson__c
       FROM Catalog_Sync_State__c
-      WHERE ResolvedTargetKey__c = :CatalogSyncStateService.buildResolvedTargetKey(
-        config
-      )
+      WHERE
+        ResolvedTargetKey__c = :CatalogSyncStateService.buildResolvedTargetKey(
+          config
+        )
       LIMIT 1
     ];
 
@@ -188,30 +203,84 @@ private class CatalogSyncStateServiceTest {
       String.valueOf(UserInfo.getUserId()),
       stateRecord.CurrentProductJobId__c
     );
-    System.assertEquals(CatalogSyncMode.FULL, stateRecord.CurrentProductRunMode__c);
+    System.assertEquals(
+      CatalogSyncMode.FULL,
+      stateRecord.CurrentProductRunMode__c
+    );
     System.assertEquals(
       'FULL_CONFIG',
       stateRecord.CurrentProductConfigDeveloperName__c
     );
     System.assertEquals(startedAt, stateRecord.CurrentProductStartedAt__c);
+    System.assert(stateRecord.RecentProductRunsJson__c.contains('FULL_CONFIG'));
+    System.assert(
+      stateRecord.RecentProductRunsJson__c.contains(
+        String.valueOf(UserInfo.getUserId())
+      )
+    );
+  }
+
+  @IsTest
+  static void testRecordSuccessfulFullSync_marksRecentRunCompleted() {
+    CatalogJobConfig__mdt config = createConfig('FULL_CONFIG', 'Full', null);
+    Datetime startedAt = Datetime.newInstanceGmt(2026, 4, 2, 9, 15, 0);
+    Datetime cutoff = Datetime.newInstanceGmt(2026, 4, 2, 9, 45, 0);
+    Id jobId = UserInfo.getUserId();
+
+    CatalogSyncStateService.recordStartedProductSync(
+      config,
+      CatalogSyncMode.FULL,
+      jobId,
+      startedAt
+    );
+
+    Test.startTest();
+    CatalogSyncStateService.recordSuccessfulFullSync(config, cutoff);
+    Test.stopTest();
+
+    Catalog_Sync_State__c stateRecord = [
+      SELECT RecentProductRunsJson__c
+      FROM Catalog_Sync_State__c
+      WHERE
+        ResolvedTargetKey__c = :CatalogSyncStateService.buildResolvedTargetKey(
+          config
+        )
+      LIMIT 1
+    ];
+
+    System.assert(stateRecord.RecentProductRunsJson__c.contains('Completed'));
+    System.assert(
+      stateRecord.RecentProductRunsJson__c.contains('2026-04-02T09:45:00Z')
+    );
   }
 
   @IsTest
   static void testEvaluateDeltaReadiness_requiresBaselineReference() {
-    CatalogJobConfig__mdt deltaConfig = createConfig('DELTA_ONLY', 'Delta', null);
+    CatalogJobConfig__mdt deltaConfig = createConfig(
+      'DELTA_ONLY',
+      'Delta',
+      null
+    );
 
-    CatalogSyncStateService.DeltaReadiness readiness =
-      CatalogSyncStateService.evaluateDeltaReadiness(deltaConfig);
+    CatalogSyncStateService.DeltaReadiness readiness = CatalogSyncStateService.evaluateDeltaReadiness(
+      deltaConfig
+    );
 
     System.assertEquals(false, readiness.isReady);
     System.assert(
-      readiness.message.contains('BaselineFullConfigDeveloperName__c is required')
+      readiness.message.contains(
+        'BaselineFullConfigDeveloperName__c is required'
+      )
     );
   }
 
   @IsTest
   static void testEvaluateDeltaReadiness_rejectsBaselineTargetMismatch() {
-    CatalogJobConfig__mdt fullConfig = createConfig('FULL_CONFIG', 'Full', null);
+    CatalogJobConfig__mdt fullConfig = createConfig(
+      'FULL_CONFIG',
+      'Full',
+      null
+    );
     fullConfig.SourceId__c = 'full-source';
     CatalogJobConfig__mdt deltaConfig = createConfig(
       'DELTA_CONFIG',
@@ -220,38 +289,54 @@ private class CatalogSyncStateServiceTest {
     );
     deltaConfig.SourceId__c = 'delta-source';
 
-    CatalogSyncStateService.testConfigsByDeveloperName =
-      new Map<String, CatalogJobConfig__mdt>{ 'FULL_CONFIG' => fullConfig };
+    CatalogSyncStateService.testConfigsByDeveloperName = new Map<String, CatalogJobConfig__mdt>{
+      'FULL_CONFIG' => fullConfig
+    };
 
-    CatalogSyncStateService.DeltaReadiness readiness =
-      CatalogSyncStateService.evaluateDeltaReadiness(deltaConfig);
+    CatalogSyncStateService.DeltaReadiness readiness = CatalogSyncStateService.evaluateDeltaReadiness(
+      deltaConfig
+    );
 
     System.assertEquals(false, readiness.isReady);
-    System.assert(readiness.message.contains('does not resolve to the same export target'));
+    System.assert(
+      readiness.message.contains('does not resolve to the same export target')
+    );
   }
 
   @IsTest
   static void testEvaluateDeltaReadiness_rejectsMissingBaselineState() {
-    CatalogJobConfig__mdt fullConfig = createConfig('FULL_CONFIG', 'Full', null);
+    CatalogJobConfig__mdt fullConfig = createConfig(
+      'FULL_CONFIG',
+      'Full',
+      null
+    );
     CatalogJobConfig__mdt deltaConfig = createConfig(
       'DELTA_CONFIG',
       'Delta',
       'FULL_CONFIG'
     );
 
-    CatalogSyncStateService.testConfigsByDeveloperName =
-      new Map<String, CatalogJobConfig__mdt>{ 'FULL_CONFIG' => fullConfig };
+    CatalogSyncStateService.testConfigsByDeveloperName = new Map<String, CatalogJobConfig__mdt>{
+      'FULL_CONFIG' => fullConfig
+    };
 
-    CatalogSyncStateService.DeltaReadiness readiness =
-      CatalogSyncStateService.evaluateDeltaReadiness(deltaConfig);
+    CatalogSyncStateService.DeltaReadiness readiness = CatalogSyncStateService.evaluateDeltaReadiness(
+      deltaConfig
+    );
 
     System.assertEquals(false, readiness.isReady);
-    System.assert(readiness.message.contains('Run the baseline full sync once'));
+    System.assert(
+      readiness.message.contains('Run the baseline full sync once')
+    );
   }
 
   @IsTest
   static void testEvaluateDeltaReadiness_acceptsMatchingBaselineState() {
-    CatalogJobConfig__mdt fullConfig = createConfig('FULL_CONFIG', 'Full', null);
+    CatalogJobConfig__mdt fullConfig = createConfig(
+      'FULL_CONFIG',
+      'Full',
+      null
+    );
     CatalogJobConfig__mdt deltaConfig = createConfig(
       'DELTA_CONFIG',
       'Delta',
@@ -260,30 +345,40 @@ private class CatalogSyncStateServiceTest {
     Datetime fullCutoff = System.now().addHours(-3);
     Datetime deltaCutoff = System.now().addHours(-1);
 
-    CatalogSyncStateService.testConfigsByDeveloperName =
-      new Map<String, CatalogJobConfig__mdt>{ 'FULL_CONFIG' => fullConfig };
-    CatalogSyncStateService.testStatesByTargetKey =
-      new Map<String, Catalog_Sync_State__c>{
-        CatalogSyncStateService.buildResolvedTargetKey(deltaConfig) => createState(
-          deltaConfig,
-          fullCutoff,
-          deltaCutoff,
-          CatalogSyncMode.DELTA,
-          'DELTA_CONFIG'
-        )
-      };
+    CatalogSyncStateService.testConfigsByDeveloperName = new Map<String, CatalogJobConfig__mdt>{
+      'FULL_CONFIG' => fullConfig
+    };
+    CatalogSyncStateService.testStatesByTargetKey = new Map<String, Catalog_Sync_State__c>{
+      CatalogSyncStateService.buildResolvedTargetKey(
+        deltaConfig
+      ) => createState(
+        deltaConfig,
+        fullCutoff,
+        deltaCutoff,
+        CatalogSyncMode.DELTA,
+        'DELTA_CONFIG'
+      )
+    };
 
-    CatalogSyncStateService.DeltaReadiness readiness =
-      CatalogSyncStateService.evaluateDeltaReadiness(deltaConfig);
+    CatalogSyncStateService.DeltaReadiness readiness = CatalogSyncStateService.evaluateDeltaReadiness(
+      deltaConfig
+    );
 
     System.assertEquals(true, readiness.isReady);
     System.assertEquals('Delta sync is ready.', readiness.message);
-    System.assertEquals(deltaCutoff, readiness.stateRecord.LastSuccessfulSyncAt__c);
+    System.assertEquals(
+      deltaCutoff,
+      readiness.stateRecord.LastSuccessfulSyncAt__c
+    );
   }
 
   @IsTest
   static void testEvaluateDeltaReadiness_rejectsActiveFullRun() {
-    CatalogJobConfig__mdt fullConfig = createConfig('FULL_CONFIG', 'Full', null);
+    CatalogJobConfig__mdt fullConfig = createConfig(
+      'FULL_CONFIG',
+      'Full',
+      null
+    );
     CatalogJobConfig__mdt deltaConfig = createConfig(
       'DELTA_CONFIG',
       'Delta',
@@ -292,27 +387,31 @@ private class CatalogSyncStateServiceTest {
     Datetime fullCutoff = Datetime.newInstanceGmt(2026, 4, 1, 10, 0, 0);
     String trackedJobId = '707000000000001AAA';
 
-    CatalogSyncStateService.testConfigsByDeveloperName =
-      new Map<String, CatalogJobConfig__mdt>{ 'FULL_CONFIG' => fullConfig };
-    CatalogSyncStateService.testStatesByTargetKey =
-      new Map<String, Catalog_Sync_State__c>{
-        CatalogSyncStateService.buildResolvedTargetKey(deltaConfig) => createState(
-          deltaConfig,
-          fullCutoff,
-          fullCutoff,
-          CatalogSyncMode.FULL,
-          'FULL_CONFIG',
-          trackedJobId,
-          CatalogSyncMode.FULL,
-          'FULL_CONFIG',
-          Datetime.newInstanceGmt(2026, 4, 2, 9, 15, 0)
-        )
-      };
-    CatalogSyncStateService.testAsyncJobStatusesById =
-      new Map<String, String>{ trackedJobId => 'Processing' };
+    CatalogSyncStateService.testConfigsByDeveloperName = new Map<String, CatalogJobConfig__mdt>{
+      'FULL_CONFIG' => fullConfig
+    };
+    CatalogSyncStateService.testStatesByTargetKey = new Map<String, Catalog_Sync_State__c>{
+      CatalogSyncStateService.buildResolvedTargetKey(
+        deltaConfig
+      ) => createState(
+        deltaConfig,
+        fullCutoff,
+        fullCutoff,
+        CatalogSyncMode.FULL,
+        'FULL_CONFIG',
+        trackedJobId,
+        CatalogSyncMode.FULL,
+        'FULL_CONFIG',
+        Datetime.newInstanceGmt(2026, 4, 2, 9, 15, 0)
+      )
+    };
+    CatalogSyncStateService.testAsyncJobStatusesById = new Map<String, String>{
+      trackedJobId => 'Processing'
+    };
 
-    CatalogSyncStateService.DeltaReadiness readiness =
-      CatalogSyncStateService.evaluateDeltaReadiness(deltaConfig);
+    CatalogSyncStateService.DeltaReadiness readiness = CatalogSyncStateService.evaluateDeltaReadiness(
+      deltaConfig
+    );
 
     System.assertEquals(false, readiness.isReady);
     System.assert(readiness.message.contains('currently running'));
@@ -320,7 +419,11 @@ private class CatalogSyncStateServiceTest {
 
   @IsTest
   static void testGetSnapshotsByDeveloperName_includesDeltaReadinessAndWatermarks() {
-    CatalogJobConfig__mdt fullConfig = createConfig('FULL_CONFIG', 'Full', null);
+    CatalogJobConfig__mdt fullConfig = createConfig(
+      'FULL_CONFIG',
+      'Full',
+      null
+    );
     CatalogJobConfig__mdt deltaConfig = createConfig(
       'DELTA_CONFIG',
       'Delta',
@@ -329,28 +432,33 @@ private class CatalogSyncStateServiceTest {
     Datetime fullCutoff = Datetime.newInstanceGmt(2026, 4, 1, 10, 0, 0);
     Datetime deltaCutoff = Datetime.newInstanceGmt(2026, 4, 1, 12, 0, 0);
 
-    CatalogSyncStateService.testConfigsByDeveloperName =
-      new Map<String, CatalogJobConfig__mdt>{ 'FULL_CONFIG' => fullConfig };
-    CatalogSyncStateService.testStatesByTargetKey =
-      new Map<String, Catalog_Sync_State__c>{
-        CatalogSyncStateService.buildResolvedTargetKey(fullConfig) => createState(
-          deltaConfig,
-          fullCutoff,
-          deltaCutoff,
-          CatalogSyncMode.DELTA,
-          'DELTA_CONFIG'
-        )
-      };
+    CatalogSyncStateService.testConfigsByDeveloperName = new Map<String, CatalogJobConfig__mdt>{
+      'FULL_CONFIG' => fullConfig
+    };
+    CatalogSyncStateService.testStatesByTargetKey = new Map<String, Catalog_Sync_State__c>{
+      CatalogSyncStateService.buildResolvedTargetKey(fullConfig) => createState(
+        deltaConfig,
+        fullCutoff,
+        deltaCutoff,
+        CatalogSyncMode.DELTA,
+        'DELTA_CONFIG'
+      )
+    };
 
-    Map<String, CatalogSyncStateService.Snapshot> snapshots =
-      CatalogSyncStateService.getSnapshotsByDeveloperName(
-        new List<CatalogJobConfig__mdt>{ fullConfig, deltaConfig }
-      );
+    Map<String, CatalogSyncStateService.Snapshot> snapshots = CatalogSyncStateService.getSnapshotsByDeveloperName(
+      new List<CatalogJobConfig__mdt>{ fullConfig, deltaConfig }
+    );
 
     System.assertEquals(true, snapshots.get('FULL_CONFIG').deltaReady);
-    System.assertEquals(false, String.isBlank(snapshots.get('FULL_CONFIG').resolvedTargetKey));
+    System.assertEquals(
+      false,
+      String.isBlank(snapshots.get('FULL_CONFIG').resolvedTargetKey)
+    );
     System.assertEquals(true, snapshots.get('DELTA_CONFIG').deltaReady);
-    System.assertEquals('FULL_CONFIG', snapshots.get('DELTA_CONFIG').baselineFullConfigDeveloperName);
+    System.assertEquals(
+      'FULL_CONFIG',
+      snapshots.get('DELTA_CONFIG').baselineFullConfigDeveloperName
+    );
     System.assertEquals(
       '2026-04-01T10:00:00Z',
       snapshots.get('DELTA_CONFIG').lastSuccessfulFullSyncAt
@@ -359,39 +467,46 @@ private class CatalogSyncStateServiceTest {
       '2026-04-01T12:00:00Z',
       snapshots.get('DELTA_CONFIG').lastSuccessfulSyncAt
     );
-    System.assertEquals(CatalogSyncMode.DELTA, snapshots.get('DELTA_CONFIG').lastRunMode);
+    System.assertEquals(
+      CatalogSyncMode.DELTA,
+      snapshots.get('DELTA_CONFIG').lastRunMode
+    );
   }
 
   @IsTest
   static void testGetSnapshotsByDeveloperName_includesActiveProductRunDetails() {
-    CatalogJobConfig__mdt fullConfig = createConfig('FULL_CONFIG', 'Full', null);
+    CatalogJobConfig__mdt fullConfig = createConfig(
+      'FULL_CONFIG',
+      'Full',
+      null
+    );
     Datetime fullCutoff = Datetime.newInstanceGmt(2026, 4, 1, 10, 0, 0);
     Datetime startedAt = Datetime.newInstanceGmt(2026, 4, 2, 9, 15, 0);
     String trackedJobId = '707000000000001AAA';
 
-    CatalogSyncStateService.testStatesByTargetKey =
-      new Map<String, Catalog_Sync_State__c>{
-        CatalogSyncStateService.buildResolvedTargetKey(fullConfig) => createState(
-          fullConfig,
-          fullCutoff,
-          fullCutoff,
-          CatalogSyncMode.FULL,
-          'FULL_CONFIG',
-          trackedJobId,
-          CatalogSyncMode.FULL,
-          'FULL_CONFIG',
-          startedAt
-        )
-      };
-    CatalogSyncStateService.testAsyncJobStatusesById =
-      new Map<String, String>{ trackedJobId => 'Processing' };
-    CatalogSyncStateService.testAsyncJobCreatedDatesById =
-      new Map<String, Datetime>{ trackedJobId => startedAt };
+    CatalogSyncStateService.testStatesByTargetKey = new Map<String, Catalog_Sync_State__c>{
+      CatalogSyncStateService.buildResolvedTargetKey(fullConfig) => createState(
+        fullConfig,
+        fullCutoff,
+        fullCutoff,
+        CatalogSyncMode.FULL,
+        'FULL_CONFIG',
+        trackedJobId,
+        CatalogSyncMode.FULL,
+        'FULL_CONFIG',
+        startedAt
+      )
+    };
+    CatalogSyncStateService.testAsyncJobStatusesById = new Map<String, String>{
+      trackedJobId => 'Processing'
+    };
+    CatalogSyncStateService.testAsyncJobCreatedDatesById = new Map<String, Datetime>{
+      trackedJobId => startedAt
+    };
 
-    Map<String, CatalogSyncStateService.Snapshot> snapshots =
-      CatalogSyncStateService.getSnapshotsByDeveloperName(
-        new List<CatalogJobConfig__mdt>{ fullConfig }
-      );
+    Map<String, CatalogSyncStateService.Snapshot> snapshots = CatalogSyncStateService.getSnapshotsByDeveloperName(
+      new List<CatalogJobConfig__mdt>{ fullConfig }
+    );
 
     CatalogSyncStateService.Snapshot snapshot = snapshots.get('FULL_CONFIG');
     System.assertEquals(trackedJobId, snapshot.currentProductJobId);
@@ -401,13 +516,71 @@ private class CatalogSyncStateServiceTest {
       'FULL_CONFIG',
       snapshot.currentProductConfigDeveloperName
     );
-    System.assertEquals('2026-04-02T09:15:00Z', snapshot.currentProductStartedAt);
+    System.assertEquals(
+      '2026-04-02T09:15:00Z',
+      snapshot.currentProductStartedAt
+    );
     System.assertEquals(true, snapshot.currentProductIsActive);
   }
 
   @IsTest
+  static void testGetSnapshotsByDeveloperName_includesRecentCompletedProductRuns() {
+    CatalogJobConfig__mdt fullConfig = createConfig(
+      'FULL_CONFIG',
+      'Full',
+      null
+    );
+    Datetime fullCutoff = Datetime.newInstanceGmt(2026, 4, 1, 10, 0, 0);
+    Catalog_Sync_State__c stateRecord = createState(
+      fullConfig,
+      fullCutoff,
+      fullCutoff,
+      CatalogSyncMode.FULL,
+      'FULL_CONFIG'
+    );
+    stateRecord.RecentProductRunsJson__c = JSON.serialize(
+      new List<Object>{
+        new Map<String, Object>{
+          'jobId' => '707000000000001AAA',
+          'runMode' => CatalogSyncMode.FULL,
+          'configDeveloperName' => 'FULL_CONFIG',
+          'status' => 'Completed',
+          'startedAt' => '2026-04-02T09:15:00Z',
+          'completedAt' => '2026-04-02T09:45:00Z'
+        }
+      }
+    );
+
+    CatalogSyncStateService.testStatesByTargetKey = new Map<String, Catalog_Sync_State__c>{
+      CatalogSyncStateService.buildResolvedTargetKey(fullConfig) => stateRecord
+    };
+
+    Map<String, CatalogSyncStateService.Snapshot> snapshots = CatalogSyncStateService.getSnapshotsByDeveloperName(
+      new List<CatalogJobConfig__mdt>{ fullConfig }
+    );
+
+    CatalogSyncStateService.Snapshot snapshot = snapshots.get('FULL_CONFIG');
+    System.assertEquals(false, snapshot.currentProductIsActive);
+    System.assertEquals(1, snapshot.recentProductRuns.size());
+    System.assertEquals(
+      '707000000000001AAA',
+      snapshot.recentProductRuns[0].jobId
+    );
+    System.assertEquals('Completed', snapshot.recentProductRuns[0].status);
+    System.assertEquals(true, snapshot.recentProductRuns[0].isTerminal);
+    System.assertEquals(
+      '2026-04-02T09:45:00Z',
+      snapshot.recentProductRuns[0].completedAt
+    );
+  }
+
+  @IsTest
   static void testGetSnapshotsByDeveloperName_blocksDeltaWhileFullRunIsActive() {
-    CatalogJobConfig__mdt fullConfig = createConfig('FULL_CONFIG', 'Full', null);
+    CatalogJobConfig__mdt fullConfig = createConfig(
+      'FULL_CONFIG',
+      'Full',
+      null
+    );
     CatalogJobConfig__mdt deltaConfig = createConfig(
       'DELTA_CONFIG',
       'Delta',
@@ -416,33 +589,36 @@ private class CatalogSyncStateServiceTest {
     Datetime fullCutoff = Datetime.newInstanceGmt(2026, 4, 1, 10, 0, 0);
     String trackedJobId = '707000000000001AAA';
 
-    CatalogSyncStateService.testConfigsByDeveloperName =
-      new Map<String, CatalogJobConfig__mdt>{ 'FULL_CONFIG' => fullConfig };
-    CatalogSyncStateService.testStatesByTargetKey =
-      new Map<String, Catalog_Sync_State__c>{
-        CatalogSyncStateService.buildResolvedTargetKey(deltaConfig) => createState(
-          deltaConfig,
-          fullCutoff,
-          fullCutoff,
-          CatalogSyncMode.FULL,
-          'FULL_CONFIG',
-          trackedJobId,
-          CatalogSyncMode.FULL,
-          'FULL_CONFIG',
-          Datetime.newInstanceGmt(2026, 4, 2, 9, 15, 0)
-        )
-      };
-    CatalogSyncStateService.testAsyncJobStatusesById =
-      new Map<String, String>{ trackedJobId => 'Processing' };
+    CatalogSyncStateService.testConfigsByDeveloperName = new Map<String, CatalogJobConfig__mdt>{
+      'FULL_CONFIG' => fullConfig
+    };
+    CatalogSyncStateService.testStatesByTargetKey = new Map<String, Catalog_Sync_State__c>{
+      CatalogSyncStateService.buildResolvedTargetKey(
+        deltaConfig
+      ) => createState(
+        deltaConfig,
+        fullCutoff,
+        fullCutoff,
+        CatalogSyncMode.FULL,
+        'FULL_CONFIG',
+        trackedJobId,
+        CatalogSyncMode.FULL,
+        'FULL_CONFIG',
+        Datetime.newInstanceGmt(2026, 4, 2, 9, 15, 0)
+      )
+    };
+    CatalogSyncStateService.testAsyncJobStatusesById = new Map<String, String>{
+      trackedJobId => 'Processing'
+    };
 
-    Map<String, CatalogSyncStateService.Snapshot> snapshots =
-      CatalogSyncStateService.getSnapshotsByDeveloperName(
-        new List<CatalogJobConfig__mdt>{ fullConfig, deltaConfig }
-      );
+    Map<String, CatalogSyncStateService.Snapshot> snapshots = CatalogSyncStateService.getSnapshotsByDeveloperName(
+      new List<CatalogJobConfig__mdt>{ fullConfig, deltaConfig }
+    );
 
     System.assertEquals(false, snapshots.get('DELTA_CONFIG').deltaReady);
     System.assert(
-      snapshots.get('DELTA_CONFIG').deltaReadinessMessage.contains('currently running')
+      snapshots.get('DELTA_CONFIG')
+        .deltaReadinessMessage.contains('currently running')
     );
   }
 }

--- a/force-app/main/default/lwc/catalogJobConsole/catalogJobConsole.js
+++ b/force-app/main/default/lwc/catalogJobConsole/catalogJobConsole.js
@@ -18,6 +18,8 @@ const POLL_INTERVAL_MS = 4000;
 const CONFIG_REFRESH_INTERVAL_MS = 15000;
 const RUN_STORAGE_KEY = "catalogJobConsoleRuns:v1";
 const ACTIVITY_STORAGE_KEY = "catalogJobConsoleActivity:v1";
+const SELECTED_CONFIG_STORAGE_KEY = "catalogJobConsoleSelectedConfig:v1";
+const WORKSPACE_FOCUS_STORAGE_KEY = "catalogJobConsoleWorkspaceFocus:v1";
 const MAX_RUNS = 24;
 const MAX_VISIBLE_COMPLETED_RUNS_PER_CONFIG = 3;
 const MAX_ACTIVITY_ITEMS = 18;
@@ -244,12 +246,40 @@ export default class CatalogJobConsole extends NavigationMixin(
       return [];
     }
 
-    return this.runSessions
+    const matchingRuns = [];
+    const includedRunKeys = new Set();
+    const includedJobIds = new Set();
+
+    this.runSessions
       .filter((runSession) => this.runMatchesSelectedConfig(runSession))
-      .sort(
-        (left, right) =>
-          this.getRunSessionSortTime(right) - this.getRunSessionSortTime(left)
-      );
+      .forEach((runSession) => {
+        this.addMatchedRunSession(
+          matchingRuns,
+          includedRunKeys,
+          includedJobIds,
+          runSession
+        );
+      });
+
+    (this.selectedConfig.recentProductRuns || [])
+      .filter(
+        (recentRun) =>
+          (recentRun.configDeveloperName || this.selectedConfig.developerName) ===
+          this.selectedConfig.developerName
+      )
+      .forEach((recentRun) => {
+        this.addMatchedRunSession(
+          matchingRuns,
+          includedRunKeys,
+          includedJobIds,
+          this.createTrackedProductRunSession(this.selectedConfig, recentRun)
+        );
+      });
+
+    return matchingRuns.sort(
+      (left, right) =>
+        this.getRunSessionSortTime(right) - this.getRunSessionSortTime(left)
+    );
   }
 
   get selectedConfigRunSessions() {
@@ -746,6 +776,7 @@ export default class CatalogJobConsole extends NavigationMixin(
     this.configs = this.configs.map((config) =>
       this.decorateConfig(config, this.selectedConfigId)
     );
+    this.persistRunState();
   }
 
   handleSelectWorkspaceFocus(event) {
@@ -755,6 +786,7 @@ export default class CatalogJobConsole extends NavigationMixin(
     }
 
     this.workspaceFocus = focus;
+    this.persistRunState();
   }
 
   async handleRunSelectedProducts() {
@@ -903,7 +935,7 @@ export default class CatalogJobConsole extends NavigationMixin(
   }
 
   downloadRunSummaryByKey(runKey) {
-    const runSession = this.runSessions.find((run) => run.runKey === runKey);
+    const runSession = this.findRunSessionByKey(runKey);
     if (!runSession) {
       this.showToast(
         "Run unavailable",
@@ -1032,24 +1064,25 @@ export default class CatalogJobConsole extends NavigationMixin(
     const configByDeveloperName = new Map(
       this.configs.map((config) => [config.developerName, config])
     );
-    const trackedConfigsByJobId = new Map();
+    const trackedRunsByJobId = new Map();
 
     this.configs.forEach((config) => {
-      if (
-        config.currentProductIsActive !== true ||
-        !config.currentProductJobId
-      ) {
-        return;
-      }
+      (config.recentProductRuns || []).forEach((recentRun) => {
+        if (!recentRun?.jobId) {
+          return;
+        }
 
-      const ownerConfig =
-        configByDeveloperName.get(config.currentProductConfigDeveloperName) ||
-        config;
+        const ownerConfig =
+          configByDeveloperName.get(recentRun.configDeveloperName) || config;
 
-      trackedConfigsByJobId.set(config.currentProductJobId, ownerConfig);
+        trackedRunsByJobId.set(recentRun.jobId, {
+          config: ownerConfig,
+          recentRun
+        });
+      });
     });
 
-    if (!trackedConfigsByJobId.size) {
+    if (!trackedRunsByJobId.size) {
       return;
     }
 
@@ -1063,13 +1096,13 @@ export default class CatalogJobConsole extends NavigationMixin(
     });
 
     const nextRuns = [];
-    trackedConfigsByJobId.forEach((config, jobId) => {
+    trackedRunsByJobId.forEach(({ config, recentRun }, jobId) => {
       if (knownJobIds.has(jobId)) {
         return;
       }
 
       knownJobIds.add(jobId);
-      nextRuns.push(this.createTrackedProductRunSession(config));
+      nextRuns.push(this.createTrackedProductRunSession(config, recentRun));
     });
 
     if (!nextRuns.length) {
@@ -1077,6 +1110,10 @@ export default class CatalogJobConsole extends NavigationMixin(
     }
 
     nextRuns.forEach((runSession) => {
+      if (runSession.jobs?.[0]?.isTerminal === true) {
+        return;
+      }
+
       const trackedJobId = runSession.jobs?.[0]?.jobId;
       this.addActivity(
         `${runSession.label}: tracking active Salesforce product job${
@@ -1093,18 +1130,28 @@ export default class CatalogJobConsole extends NavigationMixin(
     this.startPollingIfNeeded();
   }
 
-  createTrackedProductRunSession(config) {
+  createTrackedProductRunSession(config, recentRun = null) {
     const runMode =
+      recentRun?.runMode === SYNC_MODE_DELTA ||
       config.currentProductRunMode === SYNC_MODE_DELTA
         ? SYNC_MODE_DELTA
         : SYNC_MODE_FULL;
     const launchedAt =
-      config.currentProductStartedAt || new Date().toISOString();
+      recentRun?.startedAt ||
+      config.currentProductStartedAt ||
+      new Date().toISOString();
+    const jobId = recentRun?.jobId || config.currentProductJobId;
+    const status =
+      recentRun?.status || config.currentProductJobStatus || "Queued";
+    const completedAt = recentRun?.completedAt || null;
+    const isTerminal = recentRun?.isTerminal === true;
 
     return {
-      runKey: `tracked-${config.currentProductJobId}`,
+      runKey: `tracked-${jobId}`,
       developerName:
-        config.currentProductConfigDeveloperName || config.developerName,
+        recentRun?.configDeveloperName ||
+        config.currentProductConfigDeveloperName ||
+        config.developerName,
       label: config.label,
       mode: "products",
       source: "trackedProductJob",
@@ -1113,7 +1160,7 @@ export default class CatalogJobConsole extends NavigationMixin(
       launchedAt,
       jobs: [
         {
-          jobId: config.currentProductJobId,
+          jobId,
           channel: "products",
           label:
             runMode === SYNC_MODE_DELTA
@@ -1123,14 +1170,14 @@ export default class CatalogJobConsole extends NavigationMixin(
           changedRootProductCount: undefined,
           exportProductCount: undefined,
           scopeSummary: "",
-          status: config.currentProductJobStatus || "Queued",
+          status,
           jobItemsProcessed: 0,
           totalJobItems: 0,
           numberOfErrors: 0,
           extendedStatus: "",
-          isTerminal: false,
+          isTerminal,
           createdDate: launchedAt,
-          completedDate: null
+          completedDate: completedAt
         }
       ]
     };
@@ -1293,6 +1340,14 @@ export default class CatalogJobConsole extends NavigationMixin(
         ACTIVITY_STORAGE_KEY,
         JSON.stringify(this.activityFeed)
       );
+      window.sessionStorage.setItem(
+        SELECTED_CONFIG_STORAGE_KEY,
+        this.selectedConfigId || ""
+      );
+      window.sessionStorage.setItem(
+        WORKSPACE_FOCUS_STORAGE_KEY,
+        this.workspaceFocus || "status"
+      );
     } catch (error) {
       // eslint-disable-next-line no-console
       console.warn("Unable to persist run-center state", error);
@@ -1304,6 +1359,12 @@ export default class CatalogJobConsole extends NavigationMixin(
       const storedRuns = window.sessionStorage.getItem(RUN_STORAGE_KEY);
       const storedActivity =
         window.sessionStorage.getItem(ACTIVITY_STORAGE_KEY);
+      const storedSelectedConfig = window.sessionStorage.getItem(
+        SELECTED_CONFIG_STORAGE_KEY
+      );
+      const storedWorkspaceFocus = window.sessionStorage.getItem(
+        WORKSPACE_FOCUS_STORAGE_KEY
+      );
 
       if (storedRuns) {
         const parsedRuns = JSON.parse(storedRuns);
@@ -1315,6 +1376,14 @@ export default class CatalogJobConsole extends NavigationMixin(
       if (storedActivity) {
         const parsedActivity = JSON.parse(storedActivity);
         this.activityFeed = Array.isArray(parsedActivity) ? parsedActivity : [];
+      }
+
+      if (storedSelectedConfig) {
+        this.selectedConfigId = storedSelectedConfig;
+      }
+
+      if (storedWorkspaceFocus) {
+        this.workspaceFocus = storedWorkspaceFocus;
       }
     } catch (error) {
       this.runSessions = [];
@@ -1501,6 +1570,10 @@ export default class CatalogJobConsole extends NavigationMixin(
       currentProductJobId: config.currentProductJobId || "",
       currentProductConfigDeveloperName:
         config.currentProductConfigDeveloperName || "",
+      recentProductRuns: this.normalizeRecentProductRuns(
+        config.recentProductRuns,
+        config.DeveloperName
+      ),
       scheduleSummary,
       inventoryExperienceSummary: `${this.normalizeText(
         config.CatalogId__c,
@@ -2083,8 +2156,55 @@ export default class CatalogJobConsole extends NavigationMixin(
       : "cc-workspace-nav__button";
   }
 
+  addMatchedRunSession(
+    matchingRuns,
+    includedRunKeys,
+    includedJobIds,
+    runSession
+  ) {
+    if (!runSession) {
+      return;
+    }
+
+    const decoratedRun = runSession.stages
+      ? runSession
+      : this.decorateRunSession(runSession);
+    const jobIds = (decoratedRun.jobs || [])
+      .map((job) => job.jobId)
+      .filter(Boolean);
+    const runKey = jobIds.length
+      ? jobIds.join("|")
+      : decoratedRun.runKey || null;
+
+    if (jobIds.some((jobId) => includedJobIds.has(jobId))) {
+      return;
+    }
+
+    if (!jobIds.length && runKey && includedRunKeys.has(runKey)) {
+      return;
+    }
+
+    matchingRuns.push(decoratedRun);
+    jobIds.forEach((jobId) => includedJobIds.add(jobId));
+    if (runKey) {
+      includedRunKeys.add(runKey);
+    }
+  }
+
   getRunSessionSortTime(runSession) {
     return this.toTimestamp(runSession?.launchedAt) ?? 0;
+  }
+
+  findRunSessionByKey(runKey) {
+    if (!runKey) {
+      return null;
+    }
+
+    return (
+      this.runSessions.find((run) => run.runKey === runKey) ||
+      this.selectedConfigMatchedRunSessions.find((run) => run.runKey === runKey) ||
+      null
+    );
   }
 
   runMatchesSelectedConfig(runSession) {
@@ -2104,6 +2224,29 @@ export default class CatalogJobConsole extends NavigationMixin(
 
   normalizeText(value, fallback) {
     return value && String(value).trim() ? value : fallback;
+  }
+
+  normalizeRecentProductRuns(recentProductRuns, defaultDeveloperName) {
+    if (!Array.isArray(recentProductRuns)) {
+      return [];
+    }
+
+    return recentProductRuns
+      .filter((recentRun) => recentRun?.jobId)
+      .map((recentRun) => ({
+        ...recentRun,
+        jobId: recentRun.jobId,
+        runMode:
+          recentRun.runMode === SYNC_MODE_DELTA
+            ? SYNC_MODE_DELTA
+            : SYNC_MODE_FULL,
+        configDeveloperName:
+          recentRun.configDeveloperName || defaultDeveloperName,
+        status: recentRun.status || "Queued",
+        startedAt: recentRun.startedAt || null,
+        completedAt: recentRun.completedAt || null,
+        isTerminal: recentRun.isTerminal === true
+      }));
   }
 
   formatMetricMoment(isoValue, fallback) {

--- a/force-app/main/default/objects/Catalog_Sync_State__c/fields/RecentProductRunsJson__c.field-meta.xml
+++ b/force-app/main/default/objects/Catalog_Sync_State__c/fields/RecentProductRunsJson__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>RecentProductRunsJson__c</fullName>
+    <externalId>false</externalId>
+    <label>Recent Product Runs JSON</label>
+    <length>32768</length>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>10</visibleLines>
+</CustomField>

--- a/force-app/main/default/permissionsets/CoveoETL_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/CoveoETL_Admin.permissionset-meta.xml
@@ -142,6 +142,11 @@
         <field>Catalog_Sync_State__c.LastSuccessfulSyncAt__c</field>
         <readable>true</readable>
     </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Catalog_Sync_State__c.RecentProductRunsJson__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
     <hasActivationRequired>false</hasActivationRequired>
     <label>Coveo ETL Admin</label>
     <tabSettings>


### PR DESCRIPTION
## What changed

- persist recent product run history in `Catalog_Sync_State__c` through the new `RecentProductRunsJson__c` field
- expose recent product runs through the catalog job console Apex payload
- seed the Live Runs experience from org-backed recent runs so scheduled runs survive refreshes and appear for other users
- update the selected-config run monitor and run-summary download flow to work with tracked recent runs
- mark the `RecentProductRun` DTO fields as `@AuraEnabled` so Lightning receives the persisted recent-run payload
- add Apex coverage for recent completed run history and console payload exposure

## Why

The console only tracked session-launched runs plus a single active product job id. That meant scheduled runs disappeared after refresh and the Live Runs tab often looked empty even when the org had recent completed runs.

## Root cause

There were two separate issues behind the empty Live Runs experience:

1. backend state only preserved the current active product job, not a reusable recent run history for the console
2. after adding recent run persistence, the nested `RecentProductRun` DTO was still missing `@AuraEnabled`, so the LWC did not actually receive the recent-run items from Apex

## Impact

- scheduled and manual product runs now persist in org-backed history instead of only living in one browser session
- the selected config workspace can show the 3 most recent completed runs after refresh
- the console behavior is more consistent across users and browser reloads

## Validation

- deployed the full catalog console history fix to scratch org `ccetl`
- deployed the follow-up `@AuraEnabled` DTO fix to `ccetl`
- ran `CatalogJobRunnerTest` in `ccetl`
- ran `CatalogSyncStateServiceTest` in `ccetl`
